### PR TITLE
Prevent multiple concurrent checkpoint update attempts in GCP and AWS

### DIFF
--- a/storage/aws/README.md
+++ b/storage/aws/README.md
@@ -31,6 +31,10 @@ This holds batches of entries keyed by the sequence number assigned to the first
 ### `IntCoord`
 This table is used to coordinate integration of sequenced batches in the `Seq` table, and keep track of the current tree state.
 
+### `PubCoord`
+This table is used to coordinate publication of new checkpoints, ensuring that checkpoints are not published
+more frequently than configured.
+
 ## Life of a leaf
 
 1. Leaves are submitted by the binary built using Tessera via a call the storage's `Add` func.

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -111,6 +111,7 @@ type sequencer interface {
 	currentTree(ctx context.Context) (uint64, []byte, error)
 
 	// nextIndex returns the next available index in the log.
+	nextIndex(ctx context.Context) (uint64, error)
 
 	// publishTree coordinates the publication of new checkpoints based on the current integrated tree.
 	publishTree(ctx context.Context, minAge time.Duration, f func(ctx context.Context, size uint64, root []byte) error) error

--- a/storage/aws/aws_test.go
+++ b/storage/aws/aws_test.go
@@ -385,19 +385,19 @@ func TestPublishCheckpoint(t *testing.T) {
 
 	for _, test := range []struct {
 		name            string
-		cpModifiedAt    time.Time
 		publishInterval time.Duration
+		wait            time.Duration
 		wantUpdate      bool
 	}{
 		{
 			name:            "works ok",
-			cpModifiedAt:    time.Now().Add(-15 * time.Second),
-			publishInterval: 10 * time.Second,
+			publishInterval: 10 * time.Millisecond,
+			wait:            1 * time.Second,
 			wantUpdate:      true,
 		}, {
 			name:            "too soon, skip update",
-			cpModifiedAt:    time.Now().Add(-5 * time.Second),
 			publishInterval: 10 * time.Second,
+			wait:            100 * time.Millisecond,
 			wantUpdate:      false,
 		},
 	} {
@@ -417,12 +417,17 @@ func TestPublishCheckpoint(t *testing.T) {
 			if err := storage.init(ctx); err != nil {
 				t.Fatalf("storage.init: %v", err)
 			}
+			if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
+				t.Fatalf("publishCheckpoint: %v", err)
+			}
 			cpOld := []byte("bananas")
 			if err := m.setObject(ctx, layout.CheckpointPath, cpOld, "", ""); err != nil {
 				t.Fatalf("setObject(bananas): %v", err)
 			}
-			m.lMod = test.cpModifiedAt
-			if err := storage.publishCheckpoint(ctx, test.publishInterval); err != nil {
+
+			time.Sleep(test.wait)
+
+			if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
 				t.Fatalf("publishCheckpoint: %v", err)
 			}
 			cpNew, err := m.getObject(ctx, layout.CheckpointPath)
@@ -517,8 +522,7 @@ func TestStreamEntries(t *testing.T) {
 
 type memObjStore struct {
 	sync.RWMutex
-	mem  map[string][]byte
-	lMod time.Time
+	mem map[string][]byte
 }
 
 func newMemObjStore() *memObjStore {
@@ -557,8 +561,4 @@ func (m *memObjStore) setObjectIfNoneMatch(_ context.Context, obj string, data [
 	}
 	m.mem[obj] = data
 	return nil
-}
-
-func (m *memObjStore) lastModified(_ context.Context, obj string) (time.Time, error) {
-	return m.lMod, nil
 }

--- a/storage/aws/aws_test.go
+++ b/storage/aws/aws_test.go
@@ -369,7 +369,7 @@ func TestBundleRoundtrip(t *testing.T) {
 	}
 }
 
-func TestPublishCheckpoint(t *testing.T) {
+func TestPublishTree(t *testing.T) {
 	ctx := context.Background()
 	if canSkipMySQLTest(t, ctx) {
 		klog.Warningf("MySQL not available, skipping %s", t.Name())
@@ -418,7 +418,7 @@ func TestPublishCheckpoint(t *testing.T) {
 				t.Fatalf("storage.init: %v", err)
 			}
 			if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
-				t.Fatalf("publishCheckpoint: %v", err)
+				t.Fatalf("publishTree: %v", err)
 			}
 			cpOld := []byte("bananas")
 			if err := m.setObject(ctx, layout.CheckpointPath, cpOld, "", ""); err != nil {
@@ -428,7 +428,7 @@ func TestPublishCheckpoint(t *testing.T) {
 			time.Sleep(test.wait)
 
 			if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
-				t.Fatalf("publishCheckpoint: %v", err)
+				t.Fatalf("publishTree: %v", err)
 			}
 			cpNew, err := m.getObject(ctx, layout.CheckpointPath)
 			cpUpdated := !bytes.Equal(cpOld, cpNew)

--- a/storage/gcp/README.md
+++ b/storage/gcp/README.md
@@ -31,6 +31,10 @@ This holds batches of entries keyed by the sequence number assigned to the first
 ### `IntCoord`
 This table is used to coordinate integration of sequenced batches in the `Seq` table.
 
+### `PubCoord`
+This table is used to coordinate publication of new checkpoints, ensuring that checkpoints are not published
+more frequently than configured.
+
 ## Life of a leaf
 
 1. Leaves are submitted by the binary built using Tessera via a call the storage's `Add` func.

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -419,7 +419,7 @@ func TestStreamEntries(t *testing.T) {
 	}
 }
 
-func TestPublishCheckpoint(t *testing.T) {
+func TestPublishTree(t *testing.T) {
 	ctx := context.Background()
 
 	close := newSpannerDB(t)
@@ -465,7 +465,7 @@ func TestPublishCheckpoint(t *testing.T) {
 				t.Fatalf("storage.init: %v", err)
 			}
 			if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
-				t.Fatalf("publishCheckpoint: %v", err)
+				t.Fatalf("publishTree: %v", err)
 			}
 			cpOld := []byte("bananas")
 			if err := m.setObject(ctx, layout.CheckpointPath, cpOld, nil, "", ""); err != nil {
@@ -475,7 +475,7 @@ func TestPublishCheckpoint(t *testing.T) {
 			time.Sleep(test.wait)
 
 			if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
-				t.Fatalf("publishCheckpoint: %v", err)
+				t.Fatalf("publishTree: %v", err)
 			}
 			cpNew, _, err := m.getObject(ctx, layout.CheckpointPath)
 			cpUpdated := !bytes.Equal(cpOld, cpNew)


### PR DESCRIPTION
This PR fixes the issue where a log with multiple concurrently running binaries may rarely encounter a situation where more than one binary attempts to publish a new checkpoint at the same time.

While this cannot cause an integrity issue since the tree is already integrated, and all but one of the concurrent attempts will ultimately fail, it _could_ cause a little bit of extra load on witnesses and so should be avoided.