### PR TITLE
[Hammer] Make failed leaves be stickier

### DIFF
--- a/internal/hammer/loadtest/workers.go
+++ b/internal/hammer/loadtest/workers.go
@@ -200,13 +200,13 @@ func (w *LogWriter) Run(ctx context.Context) {
 		panic("LogWriter was run multiple times")
 	}
 	ctx, w.cancel = context.WithCancel(ctx)
+	newLeaf := w.gen()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-w.throttle:
 		}
-		newLeaf := w.gen()
 		lt := LeafTime{QueuedAt: time.Now()}
 		index, err := w.writer(ctx, newLeaf)
 		if err != nil {
@@ -221,6 +221,7 @@ func (w *LogWriter) Run(ctx context.Context) {
 		default:
 		}
 		klog.V(2).Infof("Wrote leaf at index %d", index)
+		newLeaf = w.gen()
 	}
 }
 


### PR DESCRIPTION
Previously if a leaf failed on a write, we would discard it and try again with another leaf. This was useful in the event that we generated an invalid leaf, because it would be temporary and the worker could continue. But in reality, we don't generate invalid leaves. So what happened is that in the event of the log temporarily pushing back to the user, leaves would be dropped. This meant that the tree size could be much smaller than the seed index that any indices that leaves had been generated from. All of this meant that on restarting the hammer against a populated log, it could spend a long time resubmitting duplicates because of this index mismatch. This is still possible, but the drift is much smaller now (at most N indices are leaked per hammer run, where N is the number of write workers).
