### PR TITLE
[API] Hide Antispam interface

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -470,10 +470,14 @@ func (t *terminator) Shutdown(ctx context.Context) error {
 }
 
 func (o *AppendOptions) WithAntispam(inMemEntries uint, as Antispam) *AppendOptions {
+	asi, ok := as.(antispam)
+	if !ok {
+		panic(fmt.Errorf("Antispam %T does not implement antispam methods", as))
+	}
 	o.addDecorators = append(o.addDecorators, newInMemoryDedupe(inMemEntries))
 	if as != nil {
-		o.addDecorators = append(o.addDecorators, as.Decorator())
-		o.followers = append(o.followers, as.Follower(o.bundleIDHasher))
+		o.addDecorators = append(o.addDecorators, asi.Decorator())
+		o.followers = append(o.followers, asi.Follower(o.bundleIDHasher))
 	}
 	return o
 }

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -469,13 +469,17 @@ func (t *terminator) Shutdown(ctx context.Context) error {
 	}
 }
 
+// WithAntispam enables in-memory antispam, and sets up persistent antispam if `as` is
+// non-nil. The size of the in-memory cache is configured with `inMemEntries`.
+// The Antispam implementations are provided with each Tessera storage layer via a
+// `NewAntispam` factory method.
 func (o *AppendOptions) WithAntispam(inMemEntries uint, as Antispam) *AppendOptions {
-	asi, ok := as.(antispam)
-	if !ok {
-		panic(fmt.Errorf("Antispam %T does not implement antispam methods", as))
-	}
 	o.addDecorators = append(o.addDecorators, newInMemoryDedupe(inMemEntries))
 	if as != nil {
+		asi, ok := as.(antispam)
+		if !ok {
+			panic(fmt.Errorf("Antispam %T does not implement antispam methods", as))
+		}
 		o.addDecorators = append(o.addDecorators, asi.Decorator())
 		o.followers = append(o.followers, asi.Follower(o.bundleIDHasher))
 	}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -88,9 +88,14 @@ type LogReader interface {
 	StreamEntries(ctx context.Context, fromEntryIdx uint64) (next func() (layout.RangeInfo, []byte, error), cancel func())
 }
 
-// Antispam describes the contract that an antispam implementation must meet in order to be used via the
-// WithAntispam option below.
-type Antispam interface {
+// Antispam is the public type for antispam implementations. Clients are expected to create one of these
+// and then pass it back in to Tessera, but are not expected to call any methods on it, nor implement it.
+// For this reason, we use `any` in order to leave the API flexible.
+//
+// Intended to be used via WithAntispam option.
+type Antispam any
+
+type antispam interface {
 	// Decorator must return a function which knows how to decorate an Appender's Add function in order
 	// to return an index previously assigned to an entry with the same identity hash, if one exists, or
 	// delegate to the next Add function in the chain otherwise.

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -95,6 +95,8 @@ type LogReader interface {
 // Intended to be used via WithAntispam option.
 type Antispam any
 
+// antispam is the internal interface for Antispam. This is only intended for implementation and usage
+// within Tessera.
 type antispam interface {
 	// Decorator must return a function which knows how to decorate an Appender's Add function in order
 	// to return an index previously assigned to an entry with the same identity hash, if one exists, or

--- a/migrate_lifecycle.go
+++ b/migrate_lifecycle.go
@@ -107,7 +107,11 @@ func (o *MigrationOptions) LeafHasher() func([]byte) ([][]byte, error) {
 // of the source tree and so no attempt is made to reject/deduplicate entries.
 func (o *MigrationOptions) WithAntispam(as Antispam) *MigrationOptions {
 	if as != nil {
-		o.followers = append(o.followers, as.Follower(o.bundleIDHasher))
+		asi, ok := as.(antispam)
+		if !ok {
+			panic(fmt.Errorf("Antispam %T does not implement antispam methods", as))
+		}
+		o.followers = append(o.followers, asi.Follower(o.bundleIDHasher))
 	}
 	return o
 }


### PR DESCRIPTION
This prevents others from implementing this (which is not currently supported), and thus gives us flexibility to change the API contract if we need to. The approach taken here is the same as taken with the Driver interface.
