### PR TITLE
[Benchmarks] Log some CPU diagnostics info

### DIFF
--- a/.github/workflows/benchmark-go-main.yml
+++ b/.github/workflows/benchmark-go-main.yml
@@ -30,7 +30,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Run benchmark
-        run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt
+        run: set -o pipefail; echo "CPU info ${{ steps.system-info.outputs.cpu-model }}"; go test ./... -benchmem -run=^$ -bench . | tee output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4

--- a/.github/workflows/benchmark-go-pr.yml
+++ b/.github/workflows/benchmark-go-pr.yml
@@ -27,8 +27,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Get CPU information
+        uses: kenchan0130/actions-system-info@19ac84a24678e27ef7e91016765c221f97b1dc28 # v1
+        id: system-info
+
       - name: Run benchmark
-        run: set -o pipefail; go test ./... -benchmem -run=^$ -bench . | tee output.txt
+        run: set -o pipefail; echo "CPU info ${{ steps.system-info.outputs.cpu-model }}"; go test ./... -benchmem -run=^$ -bench . | tee output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@d48d326b4ca9ba73ca0cd0d59f108f9e02a381c7 # v1.20.4


### PR DESCRIPTION
We see a fairly clear bimodal performance distribution for our benchmarks. Nothing in the current output indicates any difference between these runs. I have seen other projects include this CPU info in the filenames to compare apples with apples, and oranges with oranges. Before we wire this info into the file name, first dump it to the log so we can confirm that this is different between slower and faster runs.
