### PR TITLE
Simpler stream

### DIFF
--- a/internal/fsck/fsck.go
+++ b/internal/fsck/fsck.go
@@ -81,7 +81,7 @@ func Check(ctx context.Context, origin string, verifier note.Verifier, f Fetcher
 	getSize := func(_ context.Context) (uint64, error) { return cp.Size, nil }
 	// Consume the stream of bundles to re-derive the other log resources.
 	// TODO(al): consider chunking the log and doing each in parallel.
-	for b, err := range stream.StreamAdaptor(ctx, N, getSize, f.ReadEntryBundle, 0) {
+	for b, err := range stream.StreamAdaptor(ctx, N, getSize, f.ReadEntryBundle, 0, cp.Size) {
 		if err != nil {
 			klog.Warningf("StreamAdaptor: %v", err)
 			break

--- a/internal/fsck/fsck.go
+++ b/internal/fsck/fsck.go
@@ -81,7 +81,7 @@ func Check(ctx context.Context, origin string, verifier note.Verifier, f Fetcher
 	getSize := func(_ context.Context) (uint64, error) { return cp.Size, nil }
 	// Consume the stream of bundles to re-derive the other log resources.
 	// TODO(al): consider chunking the log and doing each in parallel.
-	for b, err := range stream.StreamAdaptor(ctx, N, getSize, f.ReadEntryBundle, 0, cp.Size) {
+	for b, err := range stream.EntryBundles(ctx, N, getSize, f.ReadEntryBundle, 0, cp.Size) {
 		if err != nil {
 			klog.Warningf("StreamAdaptor: %v", err)
 			break

--- a/internal/fsck/fsck.go
+++ b/internal/fsck/fsck.go
@@ -83,12 +83,10 @@ func Check(ctx context.Context, origin string, verifier note.Verifier, f Fetcher
 	// TODO(al): consider chunking the log and doing each in parallel.
 	for b, err := range stream.EntryBundles(ctx, N, getSize, f.ReadEntryBundle, 0, cp.Size) {
 		if err != nil {
-			klog.Warningf("StreamAdaptor: %v", err)
-			break
+			return fmt.Errorf("error while streaming bundles: %v", err)
 		}
 		if err := fTree.AppendBundle(b.RangeInfo, b.Data); err != nil {
-			klog.Warningf("AppendBundle(%v): %v", b.RangeInfo, err)
-			break
+			return fmt.Errorf("failure calling AppendBundle(%v): %v", b.RangeInfo, err)
 		}
 		if fTree.tree.End() >= cp.Size {
 			break

--- a/internal/stream/follower.go
+++ b/internal/stream/follower.go
@@ -16,8 +16,7 @@ package stream
 
 import (
 	"context"
-
-	"github.com/transparency-dev/tessera/api/layout"
+	"iter"
 )
 
 // Follower describes the contract of something which is required to track the contents of the local log.
@@ -56,19 +55,5 @@ type Streamer interface {
 	// entries into account.
 	NextIndex(ctx context.Context) (uint64, error)
 
-	// StreamEntries() returns functions `next` and `stop` which act like a pull iterator for
-	// consecutive entry bundles, starting with the entry bundle which contains the requested entry
-	// index.
-	//
-	// Each call to `next` will return raw entry bundle bytes along with a RangeInfo struct which
-	// contains information on which entries within that bundle are to be considered valid.
-	//
-	// next will hang if it has reached the extent of the current tree, and return once either
-	// the tree has grown and more entries are available, or cancel was called.
-	//
-	// next will cease iterating if either:
-	//   - it produces an error (e.g. via the underlying calls to the log storage)
-	//   - the returned cancel function is called
-	// and will continue to return an error if called again after either of these cases.
-	StreamEntries(ctx context.Context, fromEntryIdx uint64) (next func() (layout.RangeInfo, []byte, error), cancel func())
+	StreamEntries(ctx context.Context, fromEntryIdx uint64) iter.Seq2[Bundle, error]
 }

--- a/internal/stream/follower.go
+++ b/internal/stream/follower.go
@@ -55,10 +55,13 @@ type Streamer interface {
 	// entries into account.
 	NextIndex(ctx context.Context) (uint64, error)
 
-	// StreamEntries returns an iterator over the range of requested entries.
+	// StreamEntries returns an iterator over the range of requested entries [startEntryIdx, startEntryIdx+N).
 	//
-	// The iterator will yield either a Bundle struct or an error. The Bundle contains the raw serialised form
-	// of the entry bundle, along with a layout.RangeInfo struct which describes which of the entries in the
-	// entry bundle are part of the requested range.
+	// The iterator will yield either a Bundle struct or an error. If an error is returned the caller should
+	// stop consuming from the iterator as it's unlikely that a partial stream of entries from a transparency log
+	// is useful.
+	//
+	// The returned Bundle contains the raw serialised form of the entry bundle, along with a layout.RangeInfo
+	// struct that describes which of the entries in the entry bundle are part of the requested range.
 	StreamEntries(ctx context.Context, startEntryIdx, N uint64) iter.Seq2[Bundle, error]
 }

--- a/internal/stream/follower.go
+++ b/internal/stream/follower.go
@@ -55,5 +55,10 @@ type Streamer interface {
 	// entries into account.
 	NextIndex(ctx context.Context) (uint64, error)
 
+	// StreamEntries returns an iterator over the range of requested entries.
+	//
+	// The iterator will yield either a Bundle struct or an error. The Bundle contains the raw serialised form
+	// of the entry bundle, along with a layout.RangeInfo struct which describes which of the entries in the
+	// entry bundle are part of the requested range.
 	StreamEntries(ctx context.Context, startEntryIdx, N uint64) iter.Seq2[Bundle, error]
 }

--- a/internal/stream/follower.go
+++ b/internal/stream/follower.go
@@ -55,5 +55,5 @@ type Streamer interface {
 	// entries into account.
 	NextIndex(ctx context.Context) (uint64, error)
 
-	StreamEntries(ctx context.Context, fromEntryIdx uint64) iter.Seq2[Bundle, error]
+	StreamEntries(ctx context.Context, startEntryIdx, N uint64) iter.Seq2[Bundle, error]
 }

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -119,9 +119,16 @@ func EntryBundles(ctx context.Context, numWorkers uint, getSize GetTreeSizeFn, g
 	}()
 
 	return func(yield func(Bundle, error) bool) {
+		defer close(exit)
+
 		for f := range bundles {
 			b := f()
 			if !yield(b.b, b.err) {
+				return
+			}
+			// For now, force the iterator to stop if we've just returned an error.
+			// If there's a good reason to allow it to continue we can change this.
+			if b.err != nil {
 				return
 			}
 		}

--- a/storage/aws/antispam/aws.go
+++ b/storage/aws/antispam/aws.go
@@ -311,7 +311,7 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 				// If this is the first time around the loop we need to start the stream of entries now that we know where we want to
 				// start reading from:
 				if next == nil {
-					next, stop = iter.Pull2(stream.NewEntryIterator(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
+					next, stop = iter.Pull2(stream.Entries(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
 				}
 
 				bs := uint64(f.as.opts.MaxBatchSize)

--- a/storage/aws/antispam/aws.go
+++ b/storage/aws/antispam/aws.go
@@ -23,6 +23,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"iter"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -256,11 +257,8 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 
 	t := time.NewTicker(time.Second)
 	var (
-		entryReader *stream.EntryStreamReader[[]byte]
-		stop        func()
-
-		curEntries [][]byte
-		curIndex   uint64
+		next func() (stream.Entry[[]byte], error, bool)
+		stop func()
 	)
 	for {
 		select {
@@ -275,7 +273,7 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 		}
 
 		// Busy loop while there's work to be done
-		for workDone := true; workDone; {
+		for streamDone := false; !streamDone; {
 			select {
 			case <-ctx.Done():
 				return
@@ -304,7 +302,7 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 
 				if followFrom >= size {
 					// Our view of the log is out of date, exit the busy loop and refresh it.
-					workDone = false
+					streamDone = true
 					return nil
 				}
 
@@ -312,30 +310,36 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 
 				// If this is the first time around the loop we need to start the stream of entries now that we know where we want to
 				// start reading from:
-				if entryReader == nil {
-					next, st := lr.StreamEntries(ctx, followFrom)
-					stop = st
-					entryReader = stream.NewEntryStreamReader(next, f.bundleHasher)
+				if next == nil {
+					next, stop = iter.Pull2(stream.NewEntryIterator(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
 				}
 
 				bs := uint64(f.as.opts.MaxBatchSize)
 				if r := size - followFrom; r < bs {
 					bs = r
 				}
-				batch := make([][]byte, 0, bs)
+				curEntries := make([][]byte, 0, bs)
 				for i := range int(bs) {
-					idx, c, err := entryReader.Next()
+					e, err, ok := next()
+					if !ok {
+						// The entry stream has ended so we'll need to start a new stream next time around the loop:
+						stop()
+						next = nil
+						break
+					}
 					if err != nil {
 						return fmt.Errorf("entryReader.next: %v", err)
 					}
-					if wantIdx := followFrom + uint64(i); idx != wantIdx {
+					if wantIdx := followFrom + uint64(i); e.Index != wantIdx {
 						// We're out of sync
 						return errOutOfSync
 					}
-					batch = append(batch, c)
+					curEntries = append(curEntries, e.Entry)
 				}
-				curEntries = batch
-				curIndex = followFrom
+
+				if len(curEntries) == 0 {
+					return nil
+				}
 
 				klog.V(1).Infof("Inserting %d entries into antispam database (follow from %d of size %d)", len(curEntries), followFrom, size)
 
@@ -343,7 +347,7 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 				vals := make([]any, 0, 2*len(curEntries))
 				for i, e := range curEntries {
 					args = append(args, "(?, ?)")
-					vals = append(vals, e, curIndex+uint64(i))
+					vals = append(vals, e, followFrom+uint64(i))
 				}
 				sqlStr := fmt.Sprintf("INSERT IGNORE INTO AntispamIDSeq (h, idx) VALUES %s", strings.Join(args, ","))
 
@@ -370,14 +374,14 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 				if err != errOutOfSync {
 					klog.Errorf("Failed to commit antispam population tx: %v", err)
 				}
-				if entryReader != nil {
+				if next != nil {
 					stop()
-					entryReader = nil
+					next = nil
 					stop = nil
 				}
+				streamDone = true
 				continue
 			}
-			curEntries = nil
 		}
 	}
 }

--- a/storage/aws/antispam/aws_test.go
+++ b/storage/aws/antispam/aws_test.go
@@ -71,9 +71,18 @@ func TestAntispam(t *testing.T) {
 		t.Error("expected initial position to be 0")
 	}
 
+	a := tessera.NewPublicationAwaiter(t.Context(), fl.LogReader.ReadCheckpoint, time.Second)
 	var idx1 tessera.Index
 	idxf1 := addFn(ctx, tessera.NewEntry([]byte("one")))
+	if _, _, err := a.Await(t.Context(), idxf1); err != nil {
+		t.Fatalf("Await(1): %v", err)
+	}
+
 	idxf2 := addFn(ctx, tessera.NewEntry([]byte("two")))
+	if _, _, err := a.Await(t.Context(), idxf2); err != nil {
+		t.Fatalf("Await(2): %v", err)
+	}
+
 	if idx1, err = idxf1(); err != nil {
 		t.Fatal(err)
 	}

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -38,6 +38,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -634,7 +635,7 @@ func (lr *logResourceStore) NextIndex(ctx context.Context) (uint64, error) {
 	return lr.nextIndex(ctx)
 }
 
-func (lr *logResourceStore) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
+func (lr *logResourceStore) StreamEntries(ctx context.Context, fromEntry uint64) iter.Seq2[stream.Bundle, error] {
 	klog.Infof("StreamEntries from %d", fromEntry)
 
 	// TODO(al): Consider making this configurable.

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -635,7 +635,7 @@ func (lr *logResourceStore) NextIndex(ctx context.Context) (uint64, error) {
 	return lr.nextIndex(ctx)
 }
 
-func (lr *logResourceStore) StreamEntries(ctx context.Context, startEntry uint64, N uint64) iter.Seq2[stream.Bundle, error] {
+func (lr *logResourceStore) StreamEntries(ctx context.Context, startEntry, N uint64) iter.Seq2[stream.Bundle, error] {
 	klog.Infof("StreamEntries [%d, %d)", startEntry, startEntry+N)
 
 	// TODO(al): Consider making this configurable.

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -635,14 +635,14 @@ func (lr *logResourceStore) NextIndex(ctx context.Context) (uint64, error) {
 	return lr.nextIndex(ctx)
 }
 
-func (lr *logResourceStore) StreamEntries(ctx context.Context, fromEntry uint64) iter.Seq2[stream.Bundle, error] {
-	klog.Infof("StreamEntries from %d", fromEntry)
+func (lr *logResourceStore) StreamEntries(ctx context.Context, startEntry uint64, N uint64) iter.Seq2[stream.Bundle, error] {
+	klog.Infof("StreamEntries [%d, %d)", startEntry, startEntry+N)
 
 	// TODO(al): Consider making this configurable.
 	// Reads to S3 should be able to go highly concurrent without issue, but some performance testing should probably be undertaken.
 	// 10 works well for GCP, so start with that as a default.
 	numWorkers := uint(10)
-	return stream.StreamAdaptor(ctx, numWorkers, lr.IntegratedSize, lr.ReadEntryBundle, fromEntry)
+	return stream.StreamAdaptor(ctx, numWorkers, lr.IntegratedSize, lr.ReadEntryBundle, startEntry, N)
 }
 
 // get returns the requested object.

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -642,7 +642,7 @@ func (lr *logResourceStore) StreamEntries(ctx context.Context, startEntry, N uin
 	// Reads to S3 should be able to go highly concurrent without issue, but some performance testing should probably be undertaken.
 	// 10 works well for GCP, so start with that as a default.
 	numWorkers := uint(10)
-	return stream.StreamAdaptor(ctx, numWorkers, lr.IntegratedSize, lr.ReadEntryBundle, startEntry, N)
+	return stream.EntryBundles(ctx, numWorkers, lr.IntegratedSize, lr.ReadEntryBundle, startEntry, N)
 }
 
 // get returns the requested object.

--- a/storage/aws/aws_test.go
+++ b/storage/aws/aws_test.go
@@ -498,21 +498,16 @@ func TestStreamEntries(t *testing.T) {
 	// We'll first try to stream up to logSize1, then when we reach it we'll
 	// make the tree appear to grow to logSize2 to test resuming.
 	seenEntries := uint64(0)
-	next, stop := s.StreamEntries(ctx, 0)
 
-	for {
-		gotRI, _, gotErr := next()
+	for gotEntry, gotErr := range s.StreamEntries(ctx, 0, uint64(logSize2)) {
 		if gotErr != nil {
-			if errors.Is(gotErr, tessera.ErrNoMoreEntries) {
-				break
-			}
 			t.Fatalf("gotErr after %d: %v", seenEntries, gotErr)
 		}
-		if e := gotRI.Index*layout.EntryBundleWidth + uint64(gotRI.First); e != seenEntries {
+		if e := gotEntry.RangeInfo.Index*layout.EntryBundleWidth + uint64(gotEntry.RangeInfo.First); e != seenEntries {
 			t.Fatalf("got idx %d, want %d", e, seenEntries)
 		}
-		seenEntries += uint64(gotRI.N)
-		t.Logf("got RI %d / %d", gotRI.Index, seenEntries)
+		seenEntries += uint64(gotEntry.RangeInfo.N)
+		t.Logf("got RI %d / %d", gotEntry.RangeInfo.Index, seenEntries)
 
 		switch seenEntries {
 		case uint64(logSize1):
@@ -522,9 +517,6 @@ func TestStreamEntries(t *testing.T) {
 			t.Log("Reached logSize, growing tree")
 			logSize.Store(uint64(logSize2))
 			time.Sleep(time.Second)
-		case uint64(logSize2):
-			// We've seen all the entries we created, stop the iterator
-			stop()
 		}
 	}
 }

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -273,7 +273,7 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 				// start reading from:
 				if next == nil {
 					span.AddEvent("Start streaming entries")
-					next, stop = iter.Pull2(stream.NewEntryIterator(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
+					next, stop = iter.Pull2(stream.Entries(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
 				}
 
 				if curIndex == followFrom && curEntries != nil {

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"sync/atomic"
 	"time"
 
@@ -221,8 +222,8 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 
 	t := time.NewTicker(time.Second)
 	var (
-		entryReader *stream.EntryStreamReader[[]byte]
-		stop        func()
+		next func() (stream.Entry[[]byte], error, bool)
+		stop func()
 
 		curEntries [][]byte
 		curIndex   uint64
@@ -239,8 +240,8 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 			continue
 		}
 
-		// Busy loop while there's work to be done
-		for workDone := true; workDone; {
+		// Busy loop while there are entries to be consumed from the stream
+		for streamDone := false; !streamDone; {
 			_, err = f.as.dbPool.ReadWriteTransaction(ctx, func(ctx context.Context, txn *spanner.ReadWriteTransaction) error {
 				ctx, span := tracer.Start(ctx, "tessera.antispam.gcp.FollowTxn")
 				defer span.End()
@@ -260,7 +261,7 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 				followFrom := uint64(nextIdx)
 				if followFrom >= size {
 					// Our view of the log is out of date, exit the busy loop and refresh it.
-					workDone = false
+					streamDone = true
 					return nil
 				}
 
@@ -270,11 +271,9 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 
 				// If this is the first time around the loop we need to start the stream of entries now that we know where we want to
 				// start reading from:
-				if entryReader == nil {
+				if next == nil {
 					span.AddEvent("Start streaming entries")
-					next, st := lr.StreamEntries(ctx, followFrom)
-					stop = st
-					entryReader = stream.NewEntryStreamReader(next, f.bundleHasher)
+					next, stop = iter.Pull2(stream.NewEntryIterator(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
 				}
 
 				if curIndex == followFrom && curEntries != nil {
@@ -289,18 +288,28 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 					}
 					batch := make([][]byte, 0, bs)
 					for i := range int(bs) {
-						idx, c, err := entryReader.Next()
+						e, err, ok := next()
+						if !ok {
+							// The entry stream has ended so we'll need to start a new stream next time around the loop:
+							stop()
+							next = nil
+							break
+						}
 						if err != nil {
 							return fmt.Errorf("entryReader.next: %v", err)
 						}
-						if wantIdx := followFrom + uint64(i); idx != wantIdx {
+						if wantIdx := followFrom + uint64(i); e.Index != wantIdx {
 							// We're out of sync
 							return errOutOfSync
 						}
-						batch = append(batch, c)
+						batch = append(batch, e.Entry)
 					}
 					curEntries = batch
 					curIndex = followFrom
+				}
+
+				if len(curEntries) == 0 {
+					return nil
 				}
 
 				// Now update the index.
@@ -328,7 +337,8 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 					klog.Errorf("Failed to commit antispam population tx: %v", err)
 				}
 				stop()
-				entryReader = nil
+				next = nil
+				streamDone = true
 				continue
 			}
 			curEntries = nil

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -184,16 +184,16 @@ func (lr *LogReader) NextIndex(ctx context.Context) (uint64, error) {
 	return lr.nextIndex(ctx)
 }
 
-func (lr *LogReader) StreamEntries(ctx context.Context, fromEntry uint64) iter.Seq2[stream.Bundle, error] {
+func (lr *LogReader) StreamEntries(ctx context.Context, startEntry, N uint64) iter.Seq2[stream.Bundle, error] {
 	ctx, span := tracer.Start(ctx, "tessera.storage.gcp.StreamEntries")
 	defer span.End()
 
-	klog.Infof("StreamEntries from %d", fromEntry)
+	klog.Infof("StreamEntries from %d", startEntry)
 
 	// TODO(al): Consider making this configurable.
 	// Requests to GCS can go super parallel without too much issue, but even just 10 concurrent requests seems to provide pretty good throughput.
 	numWorkers := uint(10)
-	return stream.StreamAdaptor(ctx, numWorkers, lr.integratedSize, lr.lrs.getEntryBundle, fromEntry)
+	return stream.StreamAdaptor(ctx, numWorkers, lr.integratedSize, lr.lrs.getEntryBundle, startEntry, N)
 }
 
 func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*tessera.Appender, tessera.LogReader, error) {

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -193,7 +193,7 @@ func (lr *LogReader) StreamEntries(ctx context.Context, startEntry, N uint64) it
 	// TODO(al): Consider making this configurable.
 	// Requests to GCS can go super parallel without too much issue, but even just 10 concurrent requests seems to provide pretty good throughput.
 	numWorkers := uint(10)
-	return stream.StreamAdaptor(ctx, numWorkers, lr.integratedSize, lr.lrs.getEntryBundle, startEntry, N)
+	return stream.EntryBundles(ctx, numWorkers, lr.integratedSize, lr.lrs.getEntryBundle, startEntry, N)
 }
 
 func (s *Storage) Appender(ctx context.Context, opts *tessera.AppendOptions) (*tessera.Appender, tessera.LogReader, error) {

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -35,6 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -183,7 +184,7 @@ func (lr *LogReader) NextIndex(ctx context.Context) (uint64, error) {
 	return lr.nextIndex(ctx)
 }
 
-func (lr *LogReader) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
+func (lr *LogReader) StreamEntries(ctx context.Context, fromEntry uint64) iter.Seq2[stream.Bundle, error] {
 	ctx, span := tracer.Start(ctx, "tessera.storage.gcp.StreamEntries")
 	defer span.End()
 

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -35,6 +35,7 @@ import (
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tessera/internal/migrate"
+	"github.com/transparency-dev/tessera/internal/stream"
 	storage "github.com/transparency-dev/tessera/storage/internal"
 	"k8s.io/klog/v2"
 )
@@ -345,7 +346,7 @@ func (s *Storage) NextIndex(ctx context.Context) (uint64, error) {
 // index.
 //
 // This is part of the tessera LogReader contract.
-func (s *Storage) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
+func (s *Storage) StreamEntries(ctx context.Context, fromEntry uint64) iter.Seq2[stream.Bundle, error] {
 	type riBundle struct {
 		ri  layout.RangeInfo
 		b   []byte

--- a/storage/posix/antispam/badger.go
+++ b/storage/posix/antispam/badger.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"iter"
 	"sync/atomic"
 	"time"
 
@@ -213,8 +214,8 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 
 	t := time.NewTicker(time.Second)
 	var (
-		entryReader *stream.EntryStreamReader[[]byte]
-		stop        func()
+		next func() (stream.Entry[[]byte], error, bool)
+		stop func()
 
 		curEntries [][]byte
 		curIndex   uint64
@@ -253,7 +254,6 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 						return fmt.Errorf("failed to get nextIdx value: %v", err)
 					}
 				}
-				klog.Infof("Following from %d", followFrom)
 
 				span.SetAttributes(followFromKey.Int64(otel.Clamp64(followFrom)))
 
@@ -269,11 +269,9 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 
 				// If this is the first time around the loop we need to start the stream of entries now that we know where we want to
 				// start reading from:
-				if entryReader == nil {
+				if next == nil {
 					span.AddEvent("Start streaming entries")
-					next, st := lr.StreamEntries(ctx, followFrom)
-					stop = st
-					entryReader = stream.NewEntryStreamReader(next, f.bundleHasher)
+					next, stop = iter.Pull2(stream.NewEntryIterator(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
 				}
 
 				if curIndex == followFrom && curEntries != nil {
@@ -288,16 +286,21 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 					}
 					batch := make([][]byte, 0, bs)
 					for i := range int(bs) {
-						idx, c, err := entryReader.Next()
+						e, err, ok := next()
+						if !ok {
+							// The entry stream has ended so we'll need to start a new stream next time around the loop:
+							next = nil
+							break
+						}
 						if err != nil {
 							return fmt.Errorf("entryReader.next: %v", err)
 						}
-						if wantIdx := followFrom + uint64(i); idx != wantIdx {
-							klog.Infof("at %d, expected %d - out of sync", idx, wantIdx)
+						if wantIdx := followFrom + uint64(i); e.Index != wantIdx {
+							klog.Infof("at %d, expected %d - out of sync", e.Index, wantIdx)
 							// We're out of sync
 							return errOutOfSync
 						}
-						batch = append(batch, c)
+						batch = append(batch, e.Entry)
 					}
 					curEntries = batch
 					curIndex = followFrom
@@ -333,7 +336,7 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 					klog.Errorf("Failed to commit antispam population tx: %v", err)
 				}
 				stop()
-				entryReader = nil
+				next = nil
 				continue
 			}
 			curEntries = nil

--- a/storage/posix/antispam/badger.go
+++ b/storage/posix/antispam/badger.go
@@ -271,7 +271,7 @@ func (f *follower) Follow(ctx context.Context, lr stream.Streamer) {
 				// start reading from:
 				if next == nil {
 					span.AddEvent("Start streaming entries")
-					next, stop = iter.Pull2(stream.NewEntryIterator(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
+					next, stop = iter.Pull2(stream.Entries(lr.StreamEntries(ctx, followFrom, size-followFrom), f.bundleHasher))
 				}
 
 				if curIndex == followFrom && curEntries != nil {

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -205,13 +205,13 @@ func (l *logResourceStorage) NextIndex(ctx context.Context) (uint64, error) {
 	return l.IntegratedSize(ctx)
 }
 
-func (l *logResourceStorage) StreamEntries(ctx context.Context, fromEntry uint64) iter.Seq2[stream.Bundle, error] {
+func (l *logResourceStorage) StreamEntries(ctx context.Context, startEntry, N uint64) iter.Seq2[stream.Bundle, error] {
 	// TODO(al): Consider making this configurable.
 	// The performance of different levels of concurrency here will depend very much on the nature of the underlying storage infra,
 	// e.g. NVME will likely respond well to some concurrency, HDD less so.
 	// For now, we'll just stick to a safe default.
 	numWorkers := uint(1)
-	return stream.StreamAdaptor(ctx, numWorkers, l.IntegratedSize, l.ReadEntryBundle, fromEntry)
+	return stream.StreamAdaptor(ctx, numWorkers, l.IntegratedSize, l.ReadEntryBundle, startEntry, N)
 }
 
 // sequenceBatch writes the entries from the provided batch into the entry bundle files of the log.

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"iter"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -204,7 +205,7 @@ func (l *logResourceStorage) NextIndex(ctx context.Context) (uint64, error) {
 	return l.IntegratedSize(ctx)
 }
 
-func (l *logResourceStorage) StreamEntries(ctx context.Context, fromEntry uint64) (next func() (ri layout.RangeInfo, bundle []byte, err error), cancel func()) {
+func (l *logResourceStorage) StreamEntries(ctx context.Context, fromEntry uint64) iter.Seq2[stream.Bundle, error] {
 	// TODO(al): Consider making this configurable.
 	// The performance of different levels of concurrency here will depend very much on the nature of the underlying storage infra,
 	// e.g. NVME will likely respond well to some concurrency, HDD less so.

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -211,7 +211,7 @@ func (l *logResourceStorage) StreamEntries(ctx context.Context, startEntry, N ui
 	// e.g. NVME will likely respond well to some concurrency, HDD less so.
 	// For now, we'll just stick to a safe default.
 	numWorkers := uint(1)
-	return stream.StreamAdaptor(ctx, numWorkers, l.IntegratedSize, l.ReadEntryBundle, startEntry, N)
+	return stream.EntryBundles(ctx, numWorkers, l.IntegratedSize, l.ReadEntryBundle, startEntry, N)
 }
 
 // sequenceBatch writes the entries from the provided batch into the entry bundle files of the log.


### PR DESCRIPTION
This PR makes the `stream` package a little simpler to use/reason about:
- `StreamAdaptor` now returns a Go iterator, and iterates only over the explicitly request range of entries (previously it would hang forever and return new entries if/when the tree grew)
- `EntryReader` is replaced with an iterator wrapper for `StreamAdaptor`

