### PR TITLE
[API] Extreme refactoring to trial moving core deps out of tessera

### DIFF
--- a/README_test.go
+++ b/README_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/transparency-dev/tessera"
 
 	// Choose one!
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/storage/posix"
 	// "github.com/transparency-dev/tessera/storage/aws"
 	// "github.com/transparency-dev/tessera/storage/gcp"
@@ -77,7 +78,7 @@ func constructAndUseAppender() {
 		panic(err)
 	}
 
-	future, err := appender.Add(ctx, tessera.NewEntry(data))()
+	future, err := appender.Add(ctx, core.NewEntry(data))()
 	// #endregion
 
 	// use the vars so the compiler/linter doesn't complain.

--- a/api/state_test.go
+++ b/api/state_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
+	"github.com/transparency-dev/tessera/core"
 )
 
 func TestHashTile_MarshalTileRoundtrip(t *testing.T) {
@@ -92,7 +92,7 @@ func TestLeafBundle_MarshalTileRoundtrip(t *testing.T) {
 				if _, err := rand.Read(want[i]); err != nil {
 					t.Error(err)
 				}
-				_, _ = bundleRaw.Write(tessera.NewEntry(want[i]).MarshalBundleData(uint64(i)))
+				_, _ = bundleRaw.Write(core.NewEntry(want[i]).MarshalBundleData(uint64(i)))
 			}
 
 			tile2 := api.EntryBundle{}
@@ -151,7 +151,7 @@ func BenchmarkLeafBundle_UnmarshalText(b *testing.B) {
 	for i := range 222 {
 		// Create leaves of different lengths for interest in the parsing / memory allocation
 		leafStr := strings.Repeat(fmt.Sprintf("Leaf %d", i), i%20)
-		_, _ = bs.Write(tessera.NewEntry([]byte(leafStr)).MarshalBundleData(uint64(i)))
+		_, _ = bs.Write(core.NewEntry([]byte(leafStr)).MarshalBundleData(uint64(i)))
 	}
 	rawBundle := bs.Bytes()
 	for b.Loop() {

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -28,6 +28,7 @@ import (
 	f_log "github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/otel"
 	"github.com/transparency-dev/tessera/internal/parse"
 	"github.com/transparency-dev/tessera/internal/stream"
@@ -160,38 +161,11 @@ func init() {
 
 }
 
-// AddFn adds a new entry to be sequenced.
-// This method quickly returns an IndexFuture, which will return the index assigned
-// to the new leaf. Until this index is obtained from the future, the leaf is not durably
-// added to the log, and terminating the process may lead to this leaf being lost.
-// Once the future resolves and returns an index, the leaf is durably sequenced and will
-// be preserved even in the process terminates.
-//
-// Once a leaf is sequenced, it will be integrated into the tree soon (generally single digit
-// seconds). Until it is integrated and published, clients of the log will not be able to
-// verifiably access this value. Personalities that require blocking until the leaf is integrated
-// can use the PublicationAwaiter to wrap the call to this method.
-type AddFn func(ctx context.Context, entry *Entry) IndexFuture
-
-// IndexFuture is the signature of a function which can return an assigned index or error.
-//
-// Implementations of this func are likely to be "futures", or a promise to return this data at
-// some point in the future, and as such will block when called if the data isn't yet available.
-type IndexFuture func() (Index, error)
-
-// Index represents a durably assigned index for some entry.
-type Index struct {
-	// Index is the location in the log to which a particular entry has been assigned.
-	Index uint64
-	// IsDup is true if Index represents a previously assigned index for an identical entry.
-	IsDup bool
-}
-
 // Appender allows personalities access to the lifecycle methods associated with logs
 // in sequencing mode. This only has a single method, but other methods are likely to be added
 // such as a Shutdown method for #341.
 type Appender struct {
-	Add AddFn
+	Add core.AddFn
 }
 
 // NewAppender returns an Appender, which allows a personality to incrementally append new
@@ -240,7 +214,7 @@ func NewAppender(ctx context.Context, d Driver, opts *AppendOptions) (*Appender,
 		readCheckpoint: r.ReadCheckpoint,
 	}
 	// TODO(mhutchinson): move this into the decorators
-	a.Add = func(ctx context.Context, entry *Entry) IndexFuture {
+	a.Add = func(ctx context.Context, entry *core.Entry) core.IndexFuture {
 		return t.Add(ctx, entry)
 	}
 	return a, t.Shutdown, r, nil
@@ -350,12 +324,12 @@ func (i *integrationStats) updateStats(ctx context.Context, r LogReader) {
 
 // statsDecorator wraps a delegate AddFn with code to calculate/update
 // metric stats.
-func (i *integrationStats) statsDecorator(delegate AddFn) AddFn {
-	return func(ctx context.Context, entry *Entry) IndexFuture {
+func (i *integrationStats) statsDecorator(delegate core.AddFn) core.AddFn {
+	return func(ctx context.Context, entry *core.Entry) core.IndexFuture {
 		start := time.Now()
 		f := delegate(ctx, entry)
 
-		return func() (Index, error) {
+		return func() (core.Index, error) {
 			idx, err := f()
 			attr := []attribute.KeyValue{}
 			pushbackType := "" // This will be used for the pushback attribute below, empty string means no pushback
@@ -388,7 +362,7 @@ func (i *integrationStats) statsDecorator(delegate AddFn) AddFn {
 }
 
 type terminator struct {
-	delegate       AddFn
+	delegate       core.AddFn
 	readCheckpoint func(ctx context.Context) ([]byte, error)
 	// This mutex guards the stopped state. We use this instead of an atomic.Boolean
 	// to get the property that no readers of this state can have the lock when the
@@ -401,16 +375,16 @@ type terminator struct {
 	largestIssued atomic.Uint64
 }
 
-func (t *terminator) Add(ctx context.Context, entry *Entry) IndexFuture {
+func (t *terminator) Add(ctx context.Context, entry *core.Entry) core.IndexFuture {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.stopped {
-		return func() (Index, error) {
-			return Index{}, errors.New("appender has been shut down")
+		return func() (core.Index, error) {
+			return core.Index{}, errors.New("appender has been shut down")
 		}
 	}
 	res := t.delegate(ctx, entry)
-	return func() (Index, error) {
+	return func() (core.Index, error) {
 		i, err := res()
 		if err != nil {
 			return i, err
@@ -485,7 +459,7 @@ func NewAppendOptions() *AppendOptions {
 		entriesPath:            layout.EntriesPath,
 		bundleIDHasher:         defaultIDHasher,
 		checkpointInterval:     DefaultCheckpointInterval,
-		addDecorators:          make([]func(AddFn) AddFn, 0),
+		addDecorators:          make([]func(core.AddFn) core.AddFn, 0),
 		pushbackMaxOutstanding: DefaultPushbackMaxOutstanding,
 	}
 }
@@ -509,7 +483,7 @@ type AppendOptions struct {
 	witnesses          WitnessGroup
 	witnessOpts        WitnessOptions
 
-	addDecorators []func(AddFn) AddFn
+	addDecorators []func(core.AddFn) core.AddFn
 	followers     []stream.Follower
 }
 

--- a/await.go
+++ b/await.go
@@ -24,6 +24,7 @@ import (
 
 	"container/list"
 
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/parse"
 	"k8s.io/klog/v2"
 )
@@ -82,7 +83,7 @@ type PublicationAwaiter struct {
 // This operation can be aborted early by cancelling the context. In this event,
 // or in the event that there is an error getting a valid checkpoint, an error
 // will be returned from this method.
-func (a *PublicationAwaiter) Await(ctx context.Context, future IndexFuture) (Index, []byte, error) {
+func (a *PublicationAwaiter) Await(ctx context.Context, future core.IndexFuture) (core.Index, []byte, error) {
 	i, err := future()
 	if err != nil {
 		return i, nil, err

--- a/await_test.go
+++ b/await_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -138,9 +139,9 @@ func TestAwait(t *testing.T) {
 			}
 			awaiter := tessera.NewPublicationAwaiter(ctx, readCheckpoint, 10*time.Millisecond)
 
-			future := func() (tessera.Index, error) {
+			future := func() (core.Index, error) {
 				<-time.After(tC.fDelay)
-				return tessera.Index{Index: tC.fIndex}, tC.fErr
+				return core.Index{Index: tC.fIndex}, tC.fErr
 			}
 			i, cp, err := awaiter.Await(ctx, future)
 			if gotErr := err != nil; gotErr != tC.wantErr {
@@ -200,9 +201,9 @@ func TestAwait_multiClient(t *testing.T) {
 	wg := sync.WaitGroup{}
 	for i := range 300 {
 		index := uint64(i)
-		future := func() (tessera.Index, error) {
+		future := func() (core.Index, error) {
 			<-time.After(15 * time.Millisecond)
-			return tessera.Index{Index: index}, nil
+			return core.Index{Index: index}, nil
 		}
 		wg.Add(1)
 		go func() {

--- a/cmd/conformance/aws/main.go
+++ b/cmd/conformance/aws/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/go-sql-driver/mysql"
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/storage/aws"
 	aws_as "github.com/transparency-dev/tessera/storage/aws/antispam"
 	"golang.org/x/mod/sumdb/note"
@@ -111,7 +112,7 @@ func main() {
 			return
 		}
 
-		idx, err := appender.Add(r.Context(), tessera.NewEntry(b))()
+		idx, err := appender.Add(r.Context(), core.NewEntry(b))()
 		if err != nil {
 			if errors.Is(err, tessera.ErrPushback) {
 				w.Header().Add("Retry-After", "1")

--- a/cmd/conformance/gcp/main.go
+++ b/cmd/conformance/gcp/main.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/storage/gcp"
 	gcp_as "github.com/transparency-dev/tessera/storage/gcp/antispam"
 	"golang.org/x/mod/sumdb/note"
@@ -97,7 +98,7 @@ func main() {
 			return
 		}
 
-		f := appender.Add(r.Context(), tessera.NewEntry(b))
+		f := appender.Add(r.Context(), core.NewEntry(b))
 		idx, err := f()
 		if err != nil {
 			if errors.Is(err, tessera.ErrPushback) {

--- a/cmd/conformance/mysql/main.go
+++ b/cmd/conformance/mysql/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/storage/mysql"
 	"golang.org/x/mod/sumdb/note"
 	"k8s.io/klog/v2"
@@ -82,7 +83,7 @@ func main() {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		idx, err := appender.Add(r.Context(), tessera.NewEntry(b))()
+		idx, err := appender.Add(r.Context(), core.NewEntry(b))()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(err.Error()))

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/mod/sumdb/note"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/storage/posix"
 	badger_as "github.com/transparency-dev/tessera/storage/posix/antispam"
 	"k8s.io/klog/v2"
@@ -96,7 +97,7 @@ func main() {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		idx, err := appender.Add(r.Context(), tessera.NewEntry(b))()
+		idx, err := appender.Add(r.Context(), core.NewEntry(b))()
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, _ = w.Write([]byte(err.Error()))

--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/mod/sumdb/note"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/storage/posix"
 	"k8s.io/klog/v2"
 )
@@ -54,7 +55,7 @@ const (
 // sequence numbers assigned to the data from the provided input files.
 type entryInfo struct {
 	name string
-	f    tessera.IndexFuture
+	f    core.IndexFuture
 }
 
 func main() {
@@ -105,7 +106,7 @@ func main() {
 			klog.Exitf("Failed to read entry file %q: %q", fp, err)
 		}
 
-		f := appender.Add(ctx, tessera.NewEntry(b))
+		f := appender.Add(ctx, core.NewEntry(b))
 		indexFutures = append(indexFutures, entryInfo{name: fp, f: f})
 	}
 

--- a/core/append.go
+++ b/core/append.go
@@ -1,0 +1,44 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import "context"
+
+// AddFn adds a new entry to be sequenced.
+// This method quickly returns an IndexFuture, which will return the index assigned
+// to the new leaf. Until this index is obtained from the future, the leaf is not durably
+// added to the log, and terminating the process may lead to this leaf being lost.
+// Once the future resolves and returns an index, the leaf is durably sequenced and will
+// be preserved even in the process terminates.
+//
+// Once a leaf is sequenced, it will be integrated into the tree soon (generally single digit
+// seconds). Until it is integrated and published, clients of the log will not be able to
+// verifiably access this value. Personalities that require blocking until the leaf is integrated
+// can use the PublicationAwaiter to wrap the call to this method.
+type AddFn func(ctx context.Context, entry *Entry) IndexFuture
+
+// IndexFuture is the signature of a function which can return an assigned index or error.
+//
+// Implementations of this func are likely to be "futures", or a promise to return this data at
+// some point in the future, and as such will block when called if the data isn't yet available.
+type IndexFuture func() (Index, error)
+
+// Index represents a durably assigned index for some entry.
+type Index struct {
+	// Index is the location in the log to which a particular entry has been assigned.
+	Index uint64
+	// IsDup is true if Index represents a previously assigned index for an identical entry.
+	IsDup bool
+}

--- a/core/ct_only.go
+++ b/core/ct_only.go
@@ -1,0 +1,52 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/transparency-dev/tessera/ctonly"
+)
+
+// NewCertificateTransparencyAppender returns a function which knows how to add a CT-specific entry type to the log.
+//
+// This entry point MUST ONLY be used for CT logs participating in the CT ecosystem.
+// It should not be used as the basis for any other/new transparency application as this protocol:
+// a) embodies some techniques which are not considered to be best practice (it does this to retain backawards-compatibility with RFC6962)
+// b) is not compatible with the https://c2sp.org/tlog-tiles API which we _very strongly_ encourage you to use instead.
+//
+// Users of this MUST NOT call `Add` on the underlying Appender directly.
+//
+// Returns a future, which resolves to the assigned index in the log, or an error.
+func NewCertificateTransparencyAppender(a AddFn) func(context.Context, *ctonly.Entry) IndexFuture {
+	return func(ctx context.Context, e *ctonly.Entry) IndexFuture {
+		return a(ctx, convertCTEntry(e))
+	}
+}
+
+// convertCTEntry returns an Entry struct which will do the right thing for CT Static API logs.
+//
+// This MUST NOT be used for any other purpose.
+func convertCTEntry(e *ctonly.Entry) *Entry {
+	r := &Entry{}
+	r.internal.Identity = e.Identity()
+	r.marshalForBundle = func(idx uint64) []byte {
+		r.internal.LeafHash = e.MerkleLeafHash(idx)
+		r.internal.Data = e.LeafData(idx)
+		return r.internal.Data
+	}
+
+	return r
+}

--- a/core/entry.go
+++ b/core/entry.go
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package tessera provides an implementation of a tile-based logging framework.
-package tessera
+// Package core contains Tessera stuff that doesn't need pointers back into Tessera,
+// and that is referenced in lots of places. It is stuff that we would ideally like
+// to be in the main package, but leaving it there makes package cycles unavoidable.
+package core
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
 
 	"github.com/transparency-dev/merkle/rfc6962"
@@ -77,4 +80,10 @@ func NewEntry(data []byte) *Entry {
 		return r
 	}
 	return e
+}
+
+// identityHash calculates the antispam identity hash for the provided (single) leaf entry data.
+func identityHash(data []byte) []byte {
+	h := sha256.Sum256(data)
+	return h[:]
 }

--- a/core/entry_test.go
+++ b/core/entry_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tessera
+package core
 
 import (
 	"bytes"

--- a/ct_only.go
+++ b/ct_only.go
@@ -1,60 +1,13 @@
-// Copyright 2024 The Tessera authors. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package tessera
 
 import (
-	"context"
 	"crypto/sha256"
 	"fmt"
 
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api/layout"
-	"github.com/transparency-dev/tessera/ctonly"
 	"golang.org/x/crypto/cryptobyte"
 )
-
-// NewCertificateTransparencyAppender returns a function which knows how to add a CT-specific entry type to the log.
-//
-// This entry point MUST ONLY be used for CT logs participating in the CT ecosystem.
-// It should not be used as the basis for any other/new transparency application as this protocol:
-// a) embodies some techniques which are not considered to be best practice (it does this to retain backawards-compatibility with RFC6962)
-// b) is not compatible with the https://c2sp.org/tlog-tiles API which we _very strongly_ encourage you to use instead.
-//
-// Users of this MUST NOT call `Add` on the underlying Appender directly.
-//
-// Returns a future, which resolves to the assigned index in the log, or an error.
-func NewCertificateTransparencyAppender(a *Appender) func(context.Context, *ctonly.Entry) IndexFuture {
-	return func(ctx context.Context, e *ctonly.Entry) IndexFuture {
-		return a.Add(ctx, convertCTEntry(e))
-	}
-}
-
-// convertCTEntry returns an Entry struct which will do the right thing for CT Static API logs.
-//
-// This MUST NOT be used for any other purpose.
-func convertCTEntry(e *ctonly.Entry) *Entry {
-	r := &Entry{}
-	r.internal.Identity = e.Identity()
-	r.marshalForBundle = func(idx uint64) []byte {
-		r.internal.LeafHash = e.MerkleLeafHash(idx)
-		r.internal.Data = e.LeafData(idx)
-		return r.internal.Data
-	}
-
-	return r
-}
 
 // WithCTLayout instructs the underlying storage to use a Static CT API compatible scheme for layout.
 func (o *AppendOptions) WithCTLayout() *AppendOptions {

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -22,6 +22,7 @@ import (
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/stream"
 )
 
@@ -94,7 +95,7 @@ type Antispam interface {
 	// Decorator must return a function which knows how to decorate an Appender's Add function in order
 	// to return an index previously assigned to an entry with the same identity hash, if one exists, or
 	// delegate to the next Add function in the chain otherwise.
-	Decorator() func(AddFn) AddFn
+	Decorator() func(core.AddFn) core.AddFn
 	// Follower should return a structure which will populate the anti-spam index by tailing the contents
 	// of the log, using the provided function to turn entry bundles into identity hashes.
 	Follower(func(entryBundle []byte) ([][]byte, error)) stream.Follower

--- a/storage/aws/antispam/aws_test.go
+++ b/storage/aws/antispam/aws_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
+	"github.com/transparency-dev/tessera/core"
 	aws "github.com/transparency-dev/tessera/storage/aws/antispam"
 	"github.com/transparency-dev/tessera/testonly"
 	"k8s.io/klog/v2"
@@ -71,9 +72,9 @@ func TestAntispam(t *testing.T) {
 		t.Error("expected initial position to be 0")
 	}
 
-	var idx1 tessera.Index
-	idxf1 := addFn(ctx, tessera.NewEntry([]byte("one")))
-	idxf2 := addFn(ctx, tessera.NewEntry([]byte("two")))
+	var idx1 core.Index
+	idxf1 := addFn(ctx, core.NewEntry([]byte("one")))
+	idxf2 := addFn(ctx, core.NewEntry([]byte("two")))
 	if idx1, err = idxf1(); err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +88,7 @@ func TestAntispam(t *testing.T) {
 			break
 		}
 	}
-	dupIdx, err := addFn(ctx, tessera.NewEntry([]byte("one")))()
+	dupIdx, err := addFn(ctx, core.NewEntry([]byte("one")))()
 	if err != nil {
 		t.Error(err)
 	}

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -55,6 +55,7 @@ import (
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/migrate"
 	"github.com/transparency-dev/tessera/internal/stream"
 	storage "github.com/transparency-dev/tessera/storage/internal"
@@ -99,7 +100,7 @@ type objStore interface {
 // sequencer describes a type which knows how to sequence entries.
 type sequencer interface {
 	// assignEntries should durably allocate contiguous index numbers to the provided entries.
-	assignEntries(ctx context.Context, entries []*tessera.Entry) error
+	assignEntries(ctx context.Context, entries []*core.Entry) error
 	// consumeEntries should call the provided function with up to limit previously sequenced entries.
 	// If the call to consumeFunc returns no error, the entries should be considered to have been consumed.
 	// If any entries were successfully consumed, the implementation should also return true; this
@@ -287,7 +288,7 @@ func (a *Appender) publishCheckpointTask(ctx context.Context, interval time.Dura
 }
 
 // Add is the entrypoint for adding entries to a sequencing log.
-func (a *Appender) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
+func (a *Appender) Add(ctx context.Context, e *core.Entry) core.IndexFuture {
 	return a.queue.Add(ctx, e)
 }
 
@@ -916,7 +917,7 @@ func (s *mySQLSequencer) initDB(ctx context.Context) error {
 // Entries are allocated contiguous indices, in the order in which they appear in the entries parameter.
 // This is achieved by storing the passed-in entries in the Seq table in MySQL, keyed by the
 // index assigned to the first entry in the batch.
-func (s *mySQLSequencer) assignEntries(ctx context.Context, entries []*tessera.Entry) error {
+func (s *mySQLSequencer) assignEntries(ctx context.Context, entries []*core.Entry) error {
 	// First grab the treeSize in a non-locking read-only fashion (we don't want to block/collide with integration).
 	// We'll use this value to determine whether we need to apply back-pressure.
 	var treeSize uint64

--- a/storage/gcp/antispam/gcp.go
+++ b/storage/gcp/antispam/gcp.go
@@ -31,6 +31,7 @@ import (
 	"cloud.google.com/go/spanner/apiv1/spannerpb"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/stream"
 	"google.golang.org/grpc/codes"
 	"k8s.io/klog/v2"
@@ -146,9 +147,9 @@ func (d *AntispamStorage) index(ctx context.Context, h []byte) (*uint64, error) 
 
 // Decorator returns a function which will wrap an underlying Add delegate with
 // code to dedup against the stored data.
-func (d *AntispamStorage) Decorator() func(f tessera.AddFn) tessera.AddFn {
-	return func(delegate tessera.AddFn) tessera.AddFn {
-		return func(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
+func (d *AntispamStorage) Decorator() func(f core.AddFn) core.AddFn {
+	return func(delegate core.AddFn) core.AddFn {
+		return func(ctx context.Context, e *core.Entry) core.IndexFuture {
 			ctx, span := tracer.Start(ctx, "tessera.antispam.gcp.Add")
 			defer span.End()
 
@@ -162,14 +163,14 @@ func (d *AntispamStorage) Decorator() func(f tessera.AddFn) tessera.AddFn {
 				//
 				// We may decide in the future that serving duplicate reads is more important than catching up as quickly
 				// as possible, in which case we'd move this check down below the call to index.
-				return func() (tessera.Index, error) { return tessera.Index{}, errPushback }
+				return func() (core.Index, error) { return core.Index{}, errPushback }
 			}
 			idx, err := d.index(ctx, e.Identity())
 			if err != nil {
-				return func() (tessera.Index, error) { return tessera.Index{}, err }
+				return func() (core.Index, error) { return core.Index{}, err }
 			}
 			if idx != nil {
-				return func() (tessera.Index, error) { return tessera.Index{Index: *idx, IsDup: true}, nil }
+				return func() (core.Index, error) { return core.Index{Index: *idx, IsDup: true}, nil }
 			}
 
 			return delegate(ctx, e)

--- a/storage/gcp/antispam/gcp_test.go
+++ b/storage/gcp/antispam/gcp_test.go
@@ -25,6 +25,7 @@ import (
 	"cloud.google.com/go/spanner/spannertest"
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/testonly"
 	"k8s.io/klog/v2"
 )
@@ -85,7 +86,7 @@ func TestAntispamStorage(t *testing.T) {
 
 			entryIndex := make(map[string]uint64)
 			for i, e := range test.logEntries {
-				idx, err := fl.Appender.Add(t.Context(), tessera.NewEntry(e))()
+				idx, err := fl.Appender.Add(t.Context(), core.NewEntry(e))()
 				if err != nil {
 					t.Fatalf("Add(%d): %v", i, err)
 				}

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -52,6 +52,7 @@ import (
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/migrate"
 	"github.com/transparency-dev/tessera/internal/otel"
 	"github.com/transparency-dev/tessera/internal/stream"
@@ -97,7 +98,7 @@ type Storage struct {
 // TODO(al): rename this as it's really more of a coordination for the log.
 type sequencer interface {
 	// assignEntries should durably allocate contiguous index numbers to the provided entries.
-	assignEntries(ctx context.Context, entries []*tessera.Entry) error
+	assignEntries(ctx context.Context, entries []*core.Entry) error
 	// consumeEntries should call the provided function with up to limit previously sequenced entries.
 	// If the call to consumeFunc returns no error, the entries should be considered to have been consumed.
 	// If any entries were successfully consumed, the implementation should also return true; this
@@ -262,7 +263,7 @@ type Appender struct {
 }
 
 // Add is the entrypoint for adding entries to a sequencing log.
-func (a *Appender) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
+func (a *Appender) Add(ctx context.Context, e *core.Entry) core.IndexFuture {
 	ctx, span := tracer.Start(ctx, "tessera.storage.gcp.Add")
 	defer span.End()
 
@@ -697,7 +698,7 @@ func (s *spannerCoordinator) checkDataCompatibility(ctx context.Context) error {
 // Entries are allocated contiguous indices, in the order in which they appear in the entries parameter.
 // This is achieved by storing the passed-in entries in the Seq table in Spanner, keyed by the
 // index assigned to the first entry in the batch.
-func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*tessera.Entry) error {
+func (s *spannerCoordinator) assignEntries(ctx context.Context, entries []*core.Entry) error {
 	ctx, span := tracer.Start(ctx, "tessera.storage.gcp.assignEntries")
 	defer span.End()
 

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	storage "github.com/transparency-dev/tessera/storage/internal"
 )
 
@@ -62,9 +63,9 @@ func TestSpannerSequencerAssignEntries(t *testing.T) {
 
 	want := uint64(0)
 	for chunks := range 10 {
-		entries := []*tessera.Entry{}
+		entries := []*core.Entry{}
 		for i := range 10 + chunks {
-			entries = append(entries, tessera.NewEntry(fmt.Appendf(nil, "item %d/%d", chunks, i)))
+			entries = append(entries, core.NewEntry(fmt.Appendf(nil, "item %d/%d", chunks, i)))
 		}
 		if err := seq.assignEntries(ctx, entries); err != nil {
 			t.Fatalf("assignEntries: %v", err)
@@ -113,16 +114,16 @@ func TestSpannerSequencerPushback(t *testing.T) {
 				t.Fatalf("newSpannerCoordinator: %v", err)
 			}
 			// Set up the test scenario with the configured number of initial outstanding entries
-			entries := []*tessera.Entry{}
+			entries := []*core.Entry{}
 			for i := range test.initialEntries {
-				entries = append(entries, tessera.NewEntry(fmt.Appendf(nil, "initial item %d", i)))
+				entries = append(entries, core.NewEntry(fmt.Appendf(nil, "initial item %d", i)))
 			}
 			if err := seq.assignEntries(ctx, entries); err != nil {
 				t.Fatalf("initial assignEntries: %v", err)
 			}
 
 			// Now perform the test with a single additional entry to check for pushback
-			entries = []*tessera.Entry{tessera.NewEntry([]byte("additional"))}
+			entries = []*core.Entry{core.NewEntry([]byte("additional"))}
 			err = seq.assignEntries(ctx, entries)
 			if gotPushback := errors.Is(err, tessera.ErrPushback); gotPushback != test.wantPushback {
 				t.Fatalf("assignEntries: got pushback %t (%v), want pushback: %t", gotPushback, err, test.wantPushback)
@@ -146,9 +147,9 @@ func TestSpannerSequencerRoundTrip(t *testing.T) {
 	seq := 0
 	wantEntries := []storage.SequencedEntry{}
 	for chunks := range 10 {
-		entries := []*tessera.Entry{}
+		entries := []*core.Entry{}
 		for range 10 + chunks {
-			e := tessera.NewEntry(fmt.Appendf(nil, "item %d", seq))
+			e := core.NewEntry(fmt.Appendf(nil, "item %d", seq))
 			entries = append(entries, e)
 			wantEntries = append(wantEntries, storage.SequencedEntry{
 				BundleData: e.MarshalBundleData(uint64(seq)),
@@ -294,7 +295,7 @@ func makeBundle(t *testing.T, idx uint64, size int) []byte {
 		size = layout.EntryBundleWidth
 	}
 	for i := range size {
-		e := tessera.NewEntry(fmt.Appendf(nil, "%d:%d", idx, i))
+		e := core.NewEntry(fmt.Appendf(nil, "%d:%d", idx, i))
 		if _, err := r.Write(e.MarshalBundleData(uint64(i))); err != nil {
 			t.Fatalf("MarshalBundleEntry: %v", err)
 		}

--- a/storage/internal/integrate_test.go
+++ b/storage/internal/integrate_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/transparency-dev/merkle/compact"
 	"github.com/transparency-dev/merkle/rfc6962"
-	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"k8s.io/klog/v2"
 )
 
@@ -133,7 +133,7 @@ func TestIntegrate(t *testing.T) {
 		c := make([][]byte, chunkSize)
 		for i := range c {
 			leaf := []byte{byte(seq)}
-			entry := tessera.NewEntry(leaf)
+			entry := core.NewEntry(leaf)
 			c[i] = entry.LeafHash()
 			if err := cr.Append(rfc6962.DefaultHasher.HashLeaf(leaf), nil); err != nil {
 				t.Fatalf("compact Append: %v", err)
@@ -173,7 +173,7 @@ func BenchmarkIntegrate(b *testing.B) {
 		c := make([][]byte, chunkSize)
 		for i := range c {
 			leaf := []byte{byte(seq)}
-			entry := tessera.NewEntry(leaf)
+			entry := core.NewEntry(leaf)
 			c[i] = entry.LeafHash()
 			seq++
 		}

--- a/storage/internal/queue.go
+++ b/storage/internal/queue.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/globocom/go-buffer"
-	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 )
 
 // Queue knows how to queue up a number of entries in order, taking care of deduplication as they're added.
@@ -46,7 +46,7 @@ type Queue struct {
 // that the implementation MUST call each entry's MarshalBundleData function before attempting
 // to integrate it into the tree.
 // See the comment on Entry.MarshalBundleData for further info.
-type FlushFunc func(ctx context.Context, entries []*tessera.Entry) error
+type FlushFunc func(ctx context.Context, entries []*core.Entry) error
 
 // NewQueue creates a new queue with the specified maximum age and size.
 //
@@ -94,7 +94,7 @@ func NewQueue(ctx context.Context, maxAge time.Duration, maxSize uint, f FlushFu
 }
 
 // Add places e into the queue, and returns a func which may be called to retrieve the assigned index.
-func (q *Queue) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
+func (q *Queue) Add(ctx context.Context, e *core.Entry) core.IndexFuture {
 	_, span := tracer.Start(ctx, "tessera.storage.queue.Add")
 	defer span.End()
 
@@ -111,7 +111,7 @@ func (q *Queue) doFlush(ctx context.Context, entries []*queueItem) {
 	ctx, span := tracer.Start(ctx, "tessera.storage.queue.doFlush")
 	defer span.End()
 
-	entriesData := make([]*tessera.Entry, 0, len(entries))
+	entriesData := make([]*core.Entry, 0, len(entries))
 	for _, e := range entries {
 		entriesData = append(entriesData, e.entry)
 	}
@@ -129,18 +129,18 @@ func (q *Queue) doFlush(ctx context.Context, entries []*queueItem) {
 // The f field acts as a future for the queueItem's assigned index/error, and will
 // hang until assign is called.
 type queueItem struct {
-	entry *tessera.Entry
-	c     chan tessera.IndexFuture
-	f     tessera.IndexFuture
+	entry *core.Entry
+	c     chan core.IndexFuture
+	f     core.IndexFuture
 }
 
 // newEntry creates a new entry for the provided data.
-func newEntry(data *tessera.Entry) *queueItem {
+func newEntry(data *core.Entry) *queueItem {
 	e := &queueItem{
 		entry: data,
-		c:     make(chan tessera.IndexFuture, 1),
+		c:     make(chan core.IndexFuture, 1),
 	}
-	e.f = sync.OnceValues(func() (tessera.Index, error) {
+	e.f = sync.OnceValues(func() (core.Index, error) {
 		return (<-e.c)()
 	})
 	return e
@@ -151,14 +151,14 @@ func newEntry(data *tessera.Entry) *queueItem {
 // This func must only be called once, and will cause any current or future callers of index()
 // to be given the values provided here.
 func (e *queueItem) notify(err error) {
-	e.c <- func() (tessera.Index, error) {
+	e.c <- func() (core.Index, error) {
 		if err != nil {
-			return tessera.Index{}, err
+			return core.Index{}, err
 		}
 		if e.entry.Index() == nil {
 			panic(errors.New("logic error: flush complete, but entry was not assigned an index - did storage fail to call entry.MarshalBundleData?"))
 		}
-		return tessera.Index{Index: *e.entry.Index()}, nil
+		return core.Index{Index: *e.entry.Index()}, nil
 	}
 	close(e.c)
 }

--- a/storage/internal/queue_test.go
+++ b/storage/internal/queue_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 	storage "github.com/transparency-dev/tessera/storage/internal"
 )
 
@@ -53,12 +53,12 @@ func TestQueue(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 			assignMu := sync.Mutex{}
-			assignedItems := make([]*tessera.Entry, test.numItems)
+			assignedItems := make([]*core.Entry, test.numItems)
 			assignedIndex := uint64(0)
 
 			// flushFunc mimics sequencing storage - it takes entries, assigns them to
 			// positions in assignedItems.
-			flushFunc := func(_ context.Context, entries []*tessera.Entry) error {
+			flushFunc := func(_ context.Context, entries []*core.Entry) error {
 				assignMu.Lock()
 				defer assignMu.Unlock()
 
@@ -74,11 +74,11 @@ func TestQueue(t *testing.T) {
 			q := storage.NewQueue(ctx, test.maxWait, uint(test.maxEntries), flushFunc)
 
 			// Now submit a bunch of entries
-			adds := make([]tessera.IndexFuture, test.numItems)
-			wantEntries := make([]*tessera.Entry, test.numItems)
+			adds := make([]core.IndexFuture, test.numItems)
+			wantEntries := make([]*core.Entry, test.numItems)
 			for i := uint64(0); i < test.numItems; i++ {
 				d := fmt.Appendf(nil, "item %d", i)
-				wantEntries[i] = tessera.NewEntry(d)
+				wantEntries[i] = core.NewEntry(d)
 				adds[i] = q.Add(ctx, wantEntries[i])
 			}
 

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -34,6 +34,7 @@ import (
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/migrate"
 	storage "github.com/transparency-dev/tessera/storage/internal"
 	"k8s.io/klog/v2"
@@ -541,7 +542,7 @@ func (a *appender) publishCheckpoint(ctx context.Context, interval time.Duration
 }
 
 // Add is the entrypoint for adding entries to a sequencing log.
-func (a *appender) Add(ctx context.Context, entry *tessera.Entry) tessera.IndexFuture {
+func (a *appender) Add(ctx context.Context, entry *core.Entry) core.IndexFuture {
 	return a.queue.Add(ctx, entry)
 }
 
@@ -553,7 +554,7 @@ func (a *appender) Add(ctx context.Context, entry *tessera.Entry) tessera.IndexF
 // than one-by-one.
 //
 // TODO(#21): Separate sequencing and integration for better performance.
-func (a *appender) sequenceBatch(ctx context.Context, entries []*tessera.Entry) error {
+func (a *appender) sequenceBatch(ctx context.Context, entries []*core.Entry) error {
 	// Return when there is no entry to sequence.
 	if len(entries) == 0 {
 		return nil
@@ -598,7 +599,7 @@ func (a *appender) sequenceBatch(ctx context.Context, entries []*tessera.Entry) 
 }
 
 // appendEntries incorporates the provided entries into the log starting at fromSeq.
-func (a *appender) appendEntries(ctx context.Context, tx *sql.Tx, fromSeq uint64, entries []*tessera.Entry) error {
+func (a *appender) appendEntries(ctx context.Context, tx *sql.Tx, fromSeq uint64, entries []*core.Entry) error {
 
 	sequencedEntries := make([]storage.SequencedEntry, len(entries))
 	// Assign provisional sequence numbers to entries.

--- a/storage/mysql/mysql_test.go
+++ b/storage/mysql/mysql_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/klog/v2"
@@ -178,7 +179,7 @@ func TestGetTile(t *testing.T) {
 	for i := range treeSize {
 		wg.Go(
 			func() error {
-				_, _, err := awaiter.Await(ctx, addFn(ctx, tessera.NewEntry(fmt.Appendf(nil, "TestGetTile %d", i))))
+				_, _, err := awaiter.Await(ctx, addFn(ctx, core.NewEntry(fmt.Appendf(nil, "TestGetTile %d", i))))
 				if err != nil {
 					return fmt.Errorf("failed to prep test with entry: %v", err)
 				}
@@ -349,7 +350,7 @@ func TestParallelAdd(t *testing.T) {
 			eG := errgroup.Group{}
 			for range 1024 {
 				eG.Go(func() error {
-					_, err := addFn(ctx, tessera.NewEntry(test.entry))()
+					_, err := addFn(ctx, core.NewEntry(test.entry))()
 					return err
 				})
 			}
@@ -382,7 +383,7 @@ func TestTileRoundTrip(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			entryIndex, err := addFn(ctx, tessera.NewEntry(test.entry))()
+			entryIndex, err := addFn(ctx, core.NewEntry(test.entry))()
 			if err != nil {
 				t.Errorf("Add got err: %v", err)
 			}
@@ -433,7 +434,7 @@ func TestEntryBundleRoundTrip(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			entryIndex, err := addFn(ctx, tessera.NewEntry(test.entry))()
+			entryIndex, err := addFn(ctx, core.NewEntry(test.entry))()
 			if err != nil {
 				t.Errorf("Add got err: %v", err)
 			}
@@ -590,7 +591,7 @@ func populateEntries(t *testing.T, size uint64, s *Storage) {
 	}
 }
 
-func newTestMySQLStorage(t *testing.T, ctx context.Context) (tessera.AddFn, tessera.LogReader, *Storage) {
+func newTestMySQLStorage(t *testing.T, ctx context.Context) (core.AddFn, tessera.LogReader, *Storage) {
 	t.Helper()
 	initDatabaseSchema(ctx)
 

--- a/storage/posix/antispam/badger.go
+++ b/storage/posix/antispam/badger.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dgraph-io/badger/v4"
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/otel"
 	"github.com/transparency-dev/tessera/internal/stream"
 	"k8s.io/klog/v2"
@@ -152,9 +153,9 @@ func (d *AntispamStorage) index(ctx context.Context, h []byte) (*uint64, error) 
 
 // Decorator returns a function which will wrap an underlying Add delegate with
 // code to dedup against the stored data.
-func (d *AntispamStorage) Decorator() func(f tessera.AddFn) tessera.AddFn {
-	return func(delegate tessera.AddFn) tessera.AddFn {
-		return func(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
+func (d *AntispamStorage) Decorator() func(f core.AddFn) core.AddFn {
+	return func(delegate core.AddFn) core.AddFn {
+		return func(ctx context.Context, e *core.Entry) core.IndexFuture {
 			ctx, span := tracer.Start(ctx, "tessera.antispam.badger.Add")
 			defer span.End()
 
@@ -168,14 +169,14 @@ func (d *AntispamStorage) Decorator() func(f tessera.AddFn) tessera.AddFn {
 				//
 				// We may decide in the future that serving duplicate reads is more important than catching up as quickly
 				// as possible, in which case we'd move this check down below the call to index.
-				return func() (tessera.Index, error) { return tessera.Index{}, tessera.ErrPushback }
+				return func() (core.Index, error) { return core.Index{}, tessera.ErrPushback }
 			}
 			idx, err := d.index(ctx, e.Identity())
 			if err != nil {
-				return func() (tessera.Index, error) { return tessera.Index{}, err }
+				return func() (core.Index, error) { return core.Index{}, err }
 			}
 			if idx != nil {
-				return func() (tessera.Index, error) { return tessera.Index{Index: *idx, IsDup: true}, nil }
+				return func() (core.Index, error) { return core.Index{Index: *idx, IsDup: true}, nil }
 			}
 
 			return delegate(ctx, e)

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -33,6 +33,7 @@ import (
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/tessera/core"
 	"github.com/transparency-dev/tessera/internal/migrate"
 	"github.com/transparency-dev/tessera/internal/stream"
 	storage "github.com/transparency-dev/tessera/storage/internal"
@@ -174,7 +175,7 @@ func (s *Storage) lockFile(p string) (func() error, error) {
 // by this method have successfully evaluated. Terminating earlier than this will likely
 // mean that some of the entries added are not committed to by a checkpoint, and thus are
 // not considered to be in the log.
-func (a *appender) Add(ctx context.Context, e *tessera.Entry) tessera.IndexFuture {
+func (a *appender) Add(ctx context.Context, e *core.Entry) core.IndexFuture {
 	return a.queue.Add(ctx, e)
 }
 
@@ -219,7 +220,7 @@ func (l *logResourceStorage) StreamEntries(ctx context.Context, fromEntry uint64
 // sequenced entries are contiguous from the zeroth entry (i.e left-hand dense).
 // We try to minimise the number of partially complete entry bundles by writing entries in chunks rather
 // than one-by-one.
-func (a *appender) sequenceBatch(ctx context.Context, entries []*tessera.Entry) error {
+func (a *appender) sequenceBatch(ctx context.Context, entries []*core.Entry) error {
 	// Double locking:
 	// - The mutex `Lock()` ensures that multiple concurrent calls to this function within a task are serialised.
 	// - The POSIX `lockFile()` ensures that distinct tasks are serialised.


### PR DESCRIPTION
Entry, Index, IndexFuture, AddFn, et al, are depended on by almost all code. Having them in the main tessera package meant that extracting anything that depended on them (e.g. Antispam) to an internal package would all but guarantee a package cycle. This PR takes a look at what it would look like if these were moved into a separate package.

In my mind, this is similar to a proto package that you might find in a standard gRPC app. These core constructs are really intended to be types that everything else uses, and that should depend on very little.
