### PR TITLE
Correct LogReader interface

### DIFF
--- a/internal/stream/follower.go
+++ b/internal/stream/follower.go
@@ -48,13 +48,6 @@ type Streamer interface {
 	// log should be used. If in doubt, use ReadCheckpoint instead.
 	IntegratedSize(ctx context.Context) (uint64, error)
 
-	// NextIndex returns the first as-yet unassigned index.
-	//
-	// In a quiescent log, this will be the same as the checkpoint size. In a log with entries actively
-	// being added, this number will be higher since it will take sequenced but not-yet-integrated/not-yet-published
-	// entries into account.
-	NextIndex(ctx context.Context) (uint64, error)
-
 	// StreamEntries returns an iterator over the range of requested entries [startEntryIdx, startEntryIdx+N).
 	//
 	// The iterator will yield either a Bundle struct or an error. If an error is returned the caller should

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -49,6 +49,13 @@ type LogReader interface {
 	// The expected usage and corresponding behaviours are similar to ReadTile.
 	ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([]byte, error)
 
+	// NextIndex returns the first as-yet unassigned index.
+	//
+	// In a quiescent log, this will be the same as the checkpoint size. In a log with entries actively
+	// being added, this number will be higher since it will take sequenced but not-yet-integrated/not-yet-published
+	// entries into account.
+	NextIndex(ctx context.Context) (uint64, error)
+
 	stream.Streamer
 }
 


### PR DESCRIPTION
`NextIndex` was accidentally moved into `Streamer`, this PR moves it back to `LogReader`.