### PR TITLE
Rename some methods

### DIFF
--- a/storage/aws/aws_test.go
+++ b/storage/aws/aws_test.go
@@ -427,7 +427,7 @@ func TestPublishTree(t *testing.T) {
 			if err := storage.init(ctx); err != nil {
 				t.Fatalf("storage.init: %v", err)
 			}
-			if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
+			if err := s.publishCheckpoint(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
 				t.Fatalf("publishTree: %v", err)
 			}
 			cpOld := []byte("bananas")
@@ -437,7 +437,7 @@ func TestPublishTree(t *testing.T) {
 			updatesSeen := 0
 			for _, d := range test.attempts {
 				time.Sleep(d)
-				if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
+				if err := s.publishCheckpoint(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
 					t.Fatalf("publishTree: %v", err)
 				}
 				cpNew, err := m.getObject(ctx, layout.CheckpointPath)

--- a/storage/gcp/gcp_test.go
+++ b/storage/gcp/gcp_test.go
@@ -465,7 +465,7 @@ func TestPublishTree(t *testing.T) {
 			if err := storage.init(ctx); err != nil {
 				t.Fatalf("storage.init: %v", err)
 			}
-			if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
+			if err := s.publishCheckpoint(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
 				t.Fatalf("publishTree: %v", err)
 			}
 			cpOld := []byte("bananas")
@@ -475,7 +475,7 @@ func TestPublishTree(t *testing.T) {
 			updatesSeen := 0
 			for _, d := range test.attempts {
 				time.Sleep(d)
-				if err := s.publishTree(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
+				if err := s.publishCheckpoint(ctx, test.publishInterval, storage.publishCheckpoint); err != nil {
 					t.Fatalf("publishTree: %v", err)
 				}
 				cpNew, _, err := m.getObject(ctx, layout.CheckpointPath)


### PR DESCRIPTION
This PR is an attempt at renaming some methods in the GCP and AWS implementation for consistency and clarity.

# Job vs Task
GCP uses the `job` suffix at the end of methods, AWS `task`. I'm not attached to any specific terminology, I just picked one arbitrarily. 

# Checkpoints
The method responsible for publishing the checkpoint is called `publisherJob` in GCP, and `publishCheckpointTask`. Given that this method only publishes the checkpoint object, let's include this in the name.

# Integration
GCP names the method that kickstarts integration `sequencerJob`, since it's a job that is done by calling `appender.SEQUENCER.consumeentries`. I find that confusing because this method doesn't sequence entries. If only, it does what's typically opposed to sequencing, integration. AWS calls it `appenderJob` since it's a job that's done by `APPENDER.sequencer.consumeentries`. However, Publishing checkpoints is also done by `APPENDER.publishCheckpointTask`, so it's a bit confusing. Therefore, I settled on `appender.integrateEntries`. If this method ever does more than this, we can always rename it then.
