### PR TITLE
Memoize the outer-most AddFn

### DIFF
--- a/append_lifecycle_test.go
+++ b/append_lifecycle_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tessera
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMemoize(t *testing.T) {
+	// Set up an AddFn which will increment a counter every time it's called, and return that in the Index.
+	i := uint64(0)
+	deleg := func() (Index, error) {
+		i++
+		return Index{
+			Index: i,
+		}, nil
+	}
+	add := func(_ context.Context, _ *Entry) IndexFuture {
+		return deleg
+	}
+
+	// Create a single future (for a single Entry), and convince ourselves that the counter is being incremented
+	// each time the future is being invoked.
+	f1 := add(nil, nil)
+	a, _ := f1()
+	b, _ := f1()
+	if a.Index == b.Index {
+		t.Fatalf("a(=%d) == b(=%d)", a.Index, b.Index)
+	}
+
+	// Now create an AddFn which memoizes the result of the delegate, like we do in NewAppender, and assert that
+	// repeated calls to the future work as expected; only incrementing the counter once.
+	add = func(_ context.Context, _ *Entry) IndexFuture {
+		return memoizeFuture(deleg)
+	}
+	f2 := add(nil, nil)
+	c, _ := f2()
+	d, _ := f2()
+
+	if c.Index != d.Index {
+		t.Fatalf("c(=%d) != d(=%d)", c.Index, d.Index)
+	}
+}


### PR DESCRIPTION
This PR ensures that repeated calls to the future returned by `NewAppender` are idempotent.