### PR TITLE
Allow application to optionally configure storage infra clients

### DIFF
--- a/README_test.go
+++ b/README_test.go
@@ -48,7 +48,7 @@ func constructStorage() {
 	ctx := context.Background()
 
 	// #region construct_example
-	driver, _ := posix.New(ctx, "/tmp/mylog")
+	driver, _ := posix.New(ctx, posix.Config{Path: "/tmp/mylog"})
 	signer := createSigner()
 
 	appender, shutdown, reader, err := tessera.NewAppender(
@@ -67,7 +67,7 @@ func constructAndUseAppender() {
 	ctx := context.Background()
 	data := []byte("hello")
 
-	driver, _ := posix.New(ctx, "/tmp/mylog")
+	driver, _ := posix.New(ctx, posix.Config{Path: "/tmp/mylog"})
 	signer := createSigner()
 
 	// #region use_appender_example

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -69,7 +69,7 @@ func main() {
 	s, a := getSignersOrDie()
 
 	// Create the Tessera POSIX storage, using the directory from the --storage_dir flag
-	driver, err := posix.New(ctx, *storageDir)
+	driver, err := posix.New(ctx, posix.Config{Path: *storageDir})
 	if err != nil {
 		klog.Exitf("Failed to construct storage: %v", err)
 	}

--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -70,7 +70,9 @@ func main() {
 	// add all of these leaves without creating any intermediate checkpoints.
 	driver, err := posix.New(
 		ctx,
-		*storageDir,
+		posix.Config{
+			Path: *storageDir,
+		},
 	)
 	if err != nil {
 		klog.Exitf("Failed to construct storage: %v", err)

--- a/cmd/experimental/migrate/posix/main.go
+++ b/cmd/experimental/migrate/posix/main.go
@@ -63,7 +63,7 @@ func main() {
 		klog.Exitf("invalid checkpoint roothash %q: %v", bits[2], err)
 	}
 
-	driver, err := posix.New(ctx, *storageDir)
+	driver, err := posix.New(ctx, posix.Config{Path: *storageDir})
 	if err != nil {
 		klog.Exitf("Failed to create new POSIX storage driver: %v", err)
 	}

--- a/internal/witness/witness_test.go
+++ b/internal/witness/witness_test.go
@@ -174,7 +174,7 @@ func TestWitnessGateway_Update(t *testing.T) {
 
 func TestWitness_UpdateRequest(t *testing.T) {
 	logSignedCheckpoint, _ := loadCheckpoint(t, 9)
-	d, err := posix.New(context.Background(), "../../testdata/log/")
+	d, err := posix.New(context.Background(), posix.Config{Path: "../../testdata/log/"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -152,7 +152,7 @@ type Config struct {
 	// Maximum idle database connections in the connection pool.
 	MaxIdleConns int
 
-	// HTTPClient will be used for other HTTP requests. If unset, Tessera wil use the net/http DefaultClient.
+	// HTTPClient will be used for other HTTP requests. If unset, Tessera will use the net/http DefaultClient.
 	HTTPClient *http.Client
 }
 

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -151,6 +151,9 @@ type Config struct {
 	MaxOpenConns int
 	// Maximum idle database connections in the connection pool.
 	MaxIdleConns int
+
+	// HTTPClient will be used for other HTTP requests. If unset, Tessera wil use the net/http DefaultClient.
+	HTTPClient *http.Client
 }
 
 // New creates a new instance of the AWS based Storage.
@@ -221,7 +224,7 @@ func (s *Storage) newAppender(ctx context.Context, o objStore, seq sequencer, op
 		logStore:    logStore,
 		sequencer:   seq,
 		queue:       storage.NewQueue(ctx, opts.BatchMaxAge(), opts.BatchMaxSize(), seq.assignEntries),
-		newCP:       opts.CheckpointPublisher(logStore, http.DefaultClient),
+		newCP:       opts.CheckpointPublisher(logStore, s.cfg.HTTPClient),
 		treeUpdated: make(chan struct{}),
 	}
 

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -127,7 +127,7 @@ type Config struct {
 	GCSClient *gcs.Client
 	// SpannerClient will be used to interact with Spanner. If unset, Tessera will create one.
 	SpannerClient *spanner.Client
-	// HTTPClient will be used for other HTTP requests. If unset, Tessera wil use the net/http DefaultClient.
+	// HTTPClient will be used for other HTTP requests. If unset, Tessera will use the net/http DefaultClient.
 	HTTPClient *http.Client
 
 	// Bucket is the name of the GCS bucket to use for storing log state.

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -94,7 +94,7 @@ type logResourceStorage struct {
 type NewTreeFunc func(size uint64, root []byte) error
 
 type Config struct {
-	// HTTPClient will be used for other HTTP requests. If unset, Tessera wil use the net/http DefaultClient.
+	// HTTPClient will be used for outgoing HTTP requests. If unset, Tessera will use the net/http DefaultClient.
 	HTTPClient *http.Client
 
 	// Path is the path to a directory in which the log should be stored.

--- a/storage/posix/files_test.go
+++ b/storage/posix/files_test.go
@@ -16,6 +16,7 @@ package posix
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -36,7 +37,10 @@ func TestGarbageCollect(t *testing.T) {
 	integrateEvery := uint64(31343)
 
 	s := &Storage{
-		path: t.TempDir(),
+		cfg: Config{
+			HTTPClient: http.DefaultClient,
+			Path:       t.TempDir(),
+		},
 	}
 	sk, vk := mustGenerateKeys(t)
 
@@ -93,7 +97,7 @@ func TestGarbageCollect(t *testing.T) {
 		for _, p := range expectedPartialPrefixes(size) {
 			wantPartialPrefixes[p] = struct{}{}
 		}
-		allPartialDirs, err := findAllPartialDirs(t, s.path)
+		allPartialDirs, err := findAllPartialDirs(t, s.cfg.Path)
 		if err != nil {
 			t.Fatalf("findAllPartials: %v", err)
 		}

--- a/testonly/testlog.go
+++ b/testonly/testlog.go
@@ -46,7 +46,7 @@ func NewTestLog(t *testing.T, opts *tessera.AppendOptions) (*TestLog, func(conte
 	}
 
 	root := t.TempDir()
-	driver, err := posix.New(t.Context(), root)
+	driver, err := posix.New(t.Context(), posix.Config{Path: root})
 	if err != nil {
 		t.Fatalf("posix.New: %v", err)
 	}


### PR DESCRIPTION
This PR allows applications using Tessera to (optionally) pass pre-configured instances of infrastructure clients to the drivers, enabling applications to tune those clients to the intended usage patterns and environment (e.g. https://pkg.go.dev/google.golang.org/api/option).

In this PR, we also make `posix.New` take a `Config` struct, as in the `gcp` and `aws` packages to both improve ergonomics when switching between backends, and to open the door to adding future config options to POSIX in a backwards-compatible manner.