### PR TITLE
Don't complain if dir already exists

### DIFF
--- a/storage/posix/file_ops.go
+++ b/storage/posix/file_ops.go
@@ -62,8 +62,9 @@ func mkdirAll(name string, perm os.FileMode) (err error) {
 	case errors.Is(err, syscall.ENOENT):
 		// We'll see an ENOENT if there's a problem with a non-existant path element, so
 		// we'll recurse and create the parent directory if necessary.
+		// Don't return an error if someone else managed to get in and create the directory before us, though.
 		if dir != "" {
-			if err := mkdirAll(dir, perm); err != nil {
+			if err := mkdirAll(dir, perm); err != nil && !errors.Is(err, os.ErrExist) {
 				return err
 			}
 		}


### PR DESCRIPTION
This PR avoids an error if two routines end up racing to create a directory.
POSIX mkdir is atomic, so no need to try to sort this out with mutexes.