### PR TITLE
Disambiguation between Integration and Publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,9 +267,13 @@ Writing to the log follows this flow:
     
 Once an index has been returned, the new data is sequenced, but not necessarily integrated into the log.
 
-As discussed above in [Integration](#integration), sequenced entries will be _asynchronously_ integrated into the log and be made available via the read API.
-Some personalities may need to block until this has been performed, e.g. because they will provide the requester with an inclusion proof, which requires integration.
-Such personalities are recommended to use [Synchronous Publication](#synchronous-publication) to perform this blocking.
+As discussed above in [Integration](#integration) and [Publishing](#publishing),
+sequenced entries will be first _asynchronously_ integrated into the log, and
+then published on the read API by a second _asynchronous_ process. Some
+personalities may need to block until this has been performed, e.g. because they
+will provide the requester with an inclusion proof, which requires integration
+and publication. Such personalities are recommended to use [Synchronous Publication](#synchronous-publication)
+to perform this blocking.
 
 #### Reading from the Log
 


### PR DESCRIPTION
Personalities that need to wait should wait for a checkpoint to be published, rather than simple integration. For ease of writing, I think that it's okay to consider that "entries are published" only and only when  "checkpoint covering these entries" has been published (even if the entries will be made public before then).