### PR TITLE
Add ability to read compressed EntryBundles

### DIFF
--- a/client/fetcher.go
+++ b/client/fetcher.go
@@ -15,6 +15,8 @@
 package client
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -112,7 +114,23 @@ func (h HTTPFetcher) ReadEntryBundle(ctx context.Context, i uint64, p uint8) ([]
 
 // FileFetcher knows how to fetch log artifacts from a filesystem rooted at Root.
 type FileFetcher struct {
-	Root string
+	Root                    string
+	IsEntryBundleCompressed bool
+}
+
+// decompress decompresses gzip data if needed
+func (f FileFetcher) decompress(data []byte, compressed bool) ([]byte, error) {
+	if !compressed {
+		return data, nil
+	}
+
+	reader, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %v", err)
+	}
+	defer reader.Close()
+
+	return io.ReadAll(reader)
 }
 
 func (f FileFetcher) ReadCheckpoint(_ context.Context) ([]byte, error) {
@@ -127,6 +145,10 @@ func (f FileFetcher) ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte
 
 func (f FileFetcher) ReadEntryBundle(ctx context.Context, i uint64, p uint8) ([]byte, error) {
 	return fetcher.PartialOrFullResource(ctx, p, func(ctx context.Context, p uint8) ([]byte, error) {
-		return os.ReadFile(path.Join(f.Root, layout.EntriesPath(i, p)))
+		data, err := os.ReadFile(path.Join(f.Root, layout.EntriesPath(i, p)))
+		if err != nil {
+			return nil, err
+		}
+		return f.decompress(data, f.IsEntryBundleCompressed)
 	})
 }


### PR DESCRIPTION
Sunlight stores entrybundles in compressed format on disk. When running an `fsck` with a monitoring_url that has a `file://` schema, it would error out with read errors:
```
I0826 14:25:44.468626 3995925 fsck.go:56] Fsck: checking log of size 444
F0826 14:25:44.469148 3995925 main.go:78] FAILED:
failure calling AppendBundle({0 0 0 256}): unknown entry type 0xff at entry index 0 of bundle
```

Optionally allow for the `FileFetcher` to specify if the bundles are compressed or not. After adding a flag to the `fsck` in upstream tesseract repo, the behavior will work:

```
pim@summer:~/src/transparency-dev/tesseract$ go run ./cmd/fsck --monitoring_url=file:///home/pim/rennet2026h1/data/ -origin=rennet2026h1.log.ct.ipng.ch -public_key="MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjjELwgGMea6d7YAOP1h1Q3z5IGFOFV/kmbT0qdRgMbhQCYZdDU/fObbHf7dPEGjlg/XbBCnmHJKJySK85tzC2w==" --compressed
I0826 15:00:29.178454 4087529 main.go:337] Using verifier string: rennet2026h1.log.ct.ipng.ch+0d83f616+BTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABI4xC8IBjHmune2ADj9YdUN8+SBhThVf5Jm09KnUYDG4UAmGXQ1P3zm2x3+3TxBo5YP12wQp5hySickivObcwts=
I0826 15:00:29.178495 4087529 main.go:112] Checking issuers CAS
I0826 15:00:29.178833 4087529 fsck.go:56] Fsck: checking log of size 444
I0826 15:00:29.189873 4087529 fsck.go:111] Successfully fsck'd log with size 444 and root QgXSyRRltEmRmG5bDCbeWohy1e+0g1jzCERVL3QkxHg= (4205d2c91465b44991986e5b0c26de5a8872d5efb48358f30844552f7424c478)
I0826 15:00:29.189910 4087529 main.go:82] OK
```