### PR TITLE
Add fault-injection test for posix-oneshot

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Start Docker services (tessera-conformance-mysql-db and tessera-conformance-mysql)
         run: docker compose -f ./cmd/conformance/mysql/docker/compose.yaml up --build --detach
       - name: Run integration test 
-        run: go test -v -race ./integration/... --run_integration_test=true --log_url="http://localhost:2024" --write_log_url="http://localhost:2024" --log_public_key="transparency.dev/tessera/example+ae330e15+ASf4/L1zE859VqlfQgGzKy34l91Gl8W6wfwp+vKP62DW"
+        run: go test -v -race ./integration/. --run_integration_test=true --log_url="http://localhost:2024" --write_log_url="http://localhost:2024" --log_public_key="transparency.dev/tessera/example+ae330e15+ASf4/L1zE859VqlfQgGzKy34l91Gl8W6wfwp+vKP62DW"
       - name: Stop Docker services (tessera-conformance-mysql-db and tessera-conformance-mysql)
         if: ${{ always() }}
         run: docker compose -f ./cmd/conformance/mysql/docker/compose.yaml down
@@ -33,10 +33,21 @@ jobs:
       - name: Start Docker services (tessera-conformance-posix)
         run: docker compose -f ./cmd/conformance/posix/docker/compose.yaml up --build --detach
       - name: Run integration test 
-        run: go test -v -race ./integration/... --run_integration_test=true --log_url="file:///tmp/tessera-posix-log" --write_log_url="http://localhost:2025" --log_public_key="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
+        run: go test -v -race ./integration/. --run_integration_test=true --log_url="file:///tmp/tessera-posix-log" --write_log_url="http://localhost:2025" --log_public_key="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
       - name: What's in the box?
         if: ${{ always() }}
         run: tree /tmp/tessera-posix-log
       - name: Stop Docker services (tessera-conformance-posix)
         if: ${{ always() }}
         run: docker compose -f ./cmd/conformance/posix/docker/compose.yaml down
+
+  posix-fault-injection:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Run fault-injection test 
+        run: go test -v -race ./integration/fault/posix/... 

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.7
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.1
 	github.com/aws/smithy-go v1.22.5
+	github.com/bitfield/script v0.24.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/dgraph-io/badger/v4 v4.8.0
 	github.com/gdamore/tcell/v2 v2.9.0
@@ -64,6 +65,8 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.1 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/itchyny/gojq v0.12.13 // indirect
+	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
@@ -73,6 +76,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
+	mvdan.cc/sh/v3 v3.7.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -688,6 +688,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.38.0 h1:iV1Ko4Em/lkJIsoKyGfc0nQySi+v
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.0/go.mod h1:bEPcjW7IbolPfK67G1nilqWyoxYMSPrDiIQ3RdIdKgo=
 github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
 github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
+github.com/bitfield/script v0.24.1 h1:D4ZWu72qWL/at0rXFF+9xgs17VwyrpT6PkkBTdEz9xU=
+github.com/bitfield/script v0.24.1/go.mod h1:fv+6x4OzVsRs6qAlc7wiGq8fq1b5orhtQdtW0dwjUHI=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/brunoscheufler/aws-ecs-metadata-go v0.0.0-20221221133751-67e37ae746cd h1:C0dfBzAdNMqxokqWUysk2KTJSMmqvh9cNW1opdy5+0Q=
@@ -763,6 +765,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
+github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
+github.com/frankban/quicktest v1.14.5/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.9.0 h1:N6t+eqK7/xwtRPwxzs1PXeRWnm0H9l02CrgJ7DLn1ys=
@@ -918,6 +922,10 @@ github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyf
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/itchyny/gojq v0.12.13 h1:IxyYlHYIlspQHHTE0f3cJF0NKDMfajxViuhBLnHd/QU=
+github.com/itchyny/gojq v0.12.13/go.mod h1:JzwzAqenfhrPUuwbmEz3nu3JQmFLlQTQMUcOdnu/Sf4=
+github.com/itchyny/timefmt-go v0.1.5 h1:G0INE2la8S6ru/ZI5JecgyzbbJNs5lG1RcBqa7Jm6GE=
+github.com/itchyny/timefmt-go v0.1.5/go.mod h1:nEP7L+2YmAbT2kZ2HfSs1d8Xtw9LY8D2stDBckWakZ8=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -937,8 +945,11 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
@@ -979,6 +990,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -1423,6 +1436,8 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/tools v0.3.0/go.mod h1:/rWhSS2+zyEVwoJf8YAX6L2f0ntZ7Kn/mGgAWcipA5k=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.7.0/go.mod h1:4pg6aUX35JBAogB10C9AtvVL+qowtN4pT3CGSQex14s=
+golang.org/x/tools v0.35.0 h1:mBffYraMEf7aa0sB+NuKnuCy8qI/9Bughn8dC2Gu5r0=
+golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1764,6 +1779,8 @@ modernc.org/strutil v1.1.3/go.mod h1:MEHNA7PdEnEwLvspRMtWTNnp2nnyvMfkimT1NKNAGbw
 modernc.org/tcl v1.13.1/go.mod h1:XOLfOwzhkljL4itZkK6T72ckMgvj0BDsnKNdZVUOecw=
 modernc.org/token v1.0.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
 modernc.org/z v1.5.1/go.mod h1:eWFB510QWW5Th9YGZT81s+LwvaAs3Q2yr4sP0rmLkv8=
+mvdan.cc/sh/v3 v3.7.0 h1:lSTjdP/1xsddtaKfGg7Myu7DnlHItd3/M2tomOcNNBg=
+mvdan.cc/sh/v3 v3.7.0/go.mod h1:K2gwkaesF/D7av7Kxl0HbF5kGOd2ArupNTX3X44+8l8=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/integration/fault/posix/fault_test.go
+++ b/integration/fault/posix/fault_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC. All Rights Reserved.
+// Copyright 2025 The Tessera Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ var (
 //     posix-oneshat was actively managing/updating the log on disk.
 //  4. for each individual interesting syscall:
 //     4.1. create a new copy of the base log
-//     4.2. invoke posix-oneshot using `strace`'s `-e inject=' flag to inject the provided fauled for a single specific instance of a syscall.
+//     4.2. invoke posix-oneshot using `strace`'s `-e inject=' flag to inject the provided fault for a single specific instance of a syscall.
 //     We don't particularly care whether this fault causes posix-oneshot to exit or retry; what's important is that the on-disk
 //     representation of the log state is never left in an inconsistent or corrupt state.
 //     4.3. run `fsck` against the log-under-test to assert that the on-disk state is, indeed, self-consistent and uncorrupted.
@@ -116,7 +116,7 @@ func runFaultInjectionTest(t *testing.T, inject string) {
 			t.Run(fmt.Sprintf("%s-on-%s#%d", inject, sc, i), func(t *testing.T) {
 				t.Parallel()
 
-				// Fork the base log into a new directory
+				// Fork the base log into a new directory.
 				injectDir := filepath.Join(tmp, fmt.Sprintf("inject-%s-%d", sc, i))
 				_ = os.MkdirAll(injectDir, 0o755)
 				if output, err := script.Exec(fmt.Sprintf("cp -r %s/. %s/", baseDir, injectDir)).String(); err != nil {

--- a/integration/fault/posix/fault_test.go
+++ b/integration/fault/posix/fault_test.go
@@ -1,0 +1,260 @@
+// Copyright 2025 Google LLC. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fault_test
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bitfield/script"
+	"github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/tessera/api"
+	"github.com/transparency-dev/tessera/client"
+	"github.com/transparency-dev/tessera/fsck"
+	"k8s.io/klog/v2"
+)
+
+const (
+	testSigner   = "PRIVATE+KEY+example.com/fault_test+7f84ee58+AajLvPzbzMafNfiFvmRw1YlP7del7DYc1cr7Yntjf8yP"
+	testVerifier = "example.com/fault_test+7f84ee58+AfMY9QKMQjVcokKlKSGRvcLL8YwvpDHua/r0e64EfFIX"
+
+	treeStateFile = "/.state/treeState"
+)
+
+var (
+	// signerPath will be set to a path to a file containing a note signer key.
+	signerPath string
+	// verifierPath will be set to a path to a file containing a note verifier key corresponding to the signer key above.
+	verifierPath string
+	// oneshotPath will be set to a path to a compiled posix-oneshot binary.
+	oneshotPath string
+
+	// interestingSyscalls lists the syscalls ultimately used by posix-oneshot to manipulate the state of the log on disk.
+	interestingSyscalls = []string{"openat", "linkat", "mkdirat", "renameat", "fsync", "close", "read", "write"}
+)
+
+// TestFaultInjection is a test which tries to cause tree corruption by injecting faults into syscalls which are
+// ultimately used by the posix-oneshot application.
+//
+// This test builds and execs the `/cmd/examples/posix-oneshot` tool in order to manage some logs-under-test, and
+// uses `strace` to inspect its operation at the syscall level and to inject failures for specific calls.
+//
+// Broadly, it works as follows:
+//  1. use the posix-oneshot tool to create a "base" log, which will be used as an ancestor for all logs created during the test.
+//  2. create a copy of the base log, and use `strace` to inspect posix-oneshot as it adds a new entry to this copy.
+//  3. analyse the output from `strace` to identify a list of "interesting" (i.e. file operation related) syscalls which occurred while
+//     posix-oneshat was actively managing/updating the log on disk.
+//  4. for each individual interesting syscall:
+//     4.1. create a new copy of the base log
+//     4.2. invoke posix-oneshot using `strace`'s `-e fault=' flag to inject an `EIO` failure for a single specific instance of a syscall.
+//     We don't particularly care whether this fault causes posix-oneshot to exit or retry; what's important is that the on-disk
+//     representation of the log state is never left in an inconsistent or corrupt state.
+//     4.3. run `fsck` against the log-under-test to assert that the on-disk state is, indeed, self-consistent and uncorrupted.
+func TestFaultInjection(t *testing.T) {
+	tmp := t.TempDir()
+	setup(t, tmp)
+	baseDir := filepath.Join(tmp, "base")
+	_ = os.MkdirAll(baseDir, 0o755)
+
+	// Set up base log:
+	{
+		mustWrite(t, filepath.Join(baseDir, "base-0"), []byte("base first"))
+		p := script.Exec(growLogCommand(baseDir, filepath.Join(baseDir, "base-0")))
+		if output, err := p.String(); err != nil {
+			t.Fatalf("Failed to create base log: %v\n%s", err, output)
+		}
+	}
+
+	// Create an isolated "descendent" log which we'll use to inspect the syscalls being used by posix-oneshot while
+	// updating it:
+	count, processFn := processStraceOutput(interestingSyscalls)
+	{
+		traceDir := filepath.Join(tmp, "trace")
+		_ = os.MkdirAll(traceDir, 0o755)
+		if output, err := script.Exec(fmt.Sprintf("cp -r %s/. %s/", baseDir, traceDir)).String(); err != nil {
+			t.Fatalf("Failed to copy base log into trace directory %q: %v\n%s", traceDir, err, output)
+		}
+		mustWrite(t, filepath.Join(traceDir, "trace-0"), []byte("trace first"))
+		traceRun := script.Exec(fmt.Sprintf("strace -f -e trace=%s -e quiet=all %s", strings.Join(interestingSyscalls, ","), growLogCommand(traceDir, filepath.Join(traceDir, "trace-0"))))
+		traceRun.FilterScan(processFn)
+		o, err := traceRun.String()
+		if err != nil {
+			t.Errorf("traceRun failed: %v\n%s", err, o)
+		}
+
+		t.Logf("Syscall counts: %v", count)
+	}
+
+	// Now perform the test proper.
+	// For each individual invocation of each individual syscall used by posix-oneshot, create a new copy of the base tree and
+	// use `strace` to inject a fault into an invocation of the posix-oneshot command which attempts to add an entry to that copy.
+	for sc, c := range count {
+		for i := range c.N {
+			i := c.First + i
+
+			// Fork the base log into a new directory
+			injectDir := filepath.Join(tmp, fmt.Sprintf("inject-%s-%d", sc, i))
+			_ = os.MkdirAll(injectDir, 0o755)
+			if output, err := script.Exec(fmt.Sprintf("cp -r %s/. %s/", baseDir, injectDir)).String(); err != nil {
+				t.Fatalf("Failed to copy base log into directory %q: %v\n%s", injectDir, err, output)
+			}
+
+			// Now run posix-oneshot to add an entry, using strace to inject a fault on the ith call to the syscall named in sc:
+			// We don't really care whether this results in an error or not, but it _MUST_ be the case that the on-disk tree is
+			// left in a self-consistent state.
+			mustWrite(t, filepath.Join(injectDir, "inject-0"), fmt.Appendf(nil, "inject-%d first", i))
+			cmd := fmt.Sprintf("strace -f -e inject=%s:error=EIO:when=%d -e quiet=all %s", sc, i, growLogCommand(injectDir, filepath.Join(injectDir, "inject-0")))
+			if _, err := script.Exec(cmd).String(); err != nil {
+				t.Logf("Failed to growLog on %s: %v", injectDir, err)
+			}
+
+			// Verify that the tree on disk is self-consistent and uncorrupted by running fsck against it.
+			// Any error here is bad news.
+			if err := fsckLog(t, injectDir); err != nil {
+				t.Errorf("Fsck on %s failed: %v", injectDir, err)
+			}
+		}
+	}
+}
+
+// setup configures everything necessary for running the fault test.
+//
+// This includes building the oneshot-posix binary, writing out test keys,
+// and figuring out paths.
+func setup(t *testing.T, outDir string) {
+	t.Helper()
+
+	oneshotPath = filepath.Join(outDir, "posix-oneshot")
+	signerPath = filepath.Join(outDir, "test.sec")
+	verifierPath = filepath.Join(outDir, "test.pub")
+
+	if o, err := script.Exec(fmt.Sprintf("go build -o %s ../../../cmd/examples/posix-oneshot", oneshotPath)).String(); err != nil {
+		t.Fatalf("Failed to build posix-oneshot: %v\n%s", err, o)
+	}
+
+	if err := os.WriteFile(signerPath, []byte(testSigner), 0o644); err != nil {
+		t.Fatalf("Failed to write %s: %v", signerPath, err)
+	}
+	if err := os.WriteFile(verifierPath, []byte(testVerifier), 0o644); err != nil {
+		t.Fatalf("Failed to write %s: %v", verifierPath, err)
+	}
+}
+
+// growLogCommand returns a formatted shell command for executing posix-oneshot on a log stored at the provided location
+// to integrate the provided new entry files.
+func growLogCommand(storagePath string, entriesGlob string) string {
+	return fmt.Sprintf("%s --private_key=%s --storage_dir=%s --entries=%s", oneshotPath, signerPath, storagePath, entriesGlob)
+}
+
+// calls represents a range of invocations of a particular syscall.
+type calls struct {
+	// First is the index of the first "interesting" use of the corresponding syscall - i.e. it occurred
+	// while posix-oneshot was actually modifying/processing the log.
+	First int
+	// N is the number of invocations of the syscall which occurred during the period posix-oneshot was
+	// modifying/processing the log.
+	N int
+}
+
+// processStraceOutput reads the output from the strace command being used to inspect the goings-on
+// inside posix-oneshot.
+//
+// This function returns a map which contains information about calls to the list of provided
+// "interesting" syscalls, and a function which can be used to filter the output down to a heuristically
+// determined subset for human-inspection purposes.
+//
+// The syscalls we're interested in are pretty common (e.g. Go's runtime wants to read a bunch of
+// files/devices when we first start a compiled Go program, posix-oneshot wants to read keys from
+// disk, etc.), so we attempt to pare down the _actually_ interesting calls by ignoring anything
+// which happens before execution has reached the "actual" posix-oneshot application code. We do this by
+// looking for the very first syscall referencing the ".state/treeState" file - this is tessera opening the
+// tree.
+func processStraceOutput(syscalls []string) (map[string]calls, func(string, io.Writer)) {
+	// m is a map of syscall name to information about its invocations.
+	m := make(map[string]calls)
+	// oneshotStarted will be false until we've seen the string "/.state/treeState" in one of the syscalls.
+	// we use this to determine whether syscalls should be skipped or not.
+	oneshotStarted := false
+	return m, func(line string, w io.Writer) {
+		// When we see the treeStateFile referenced by a syscall we know posix-oneshot has started up
+		// and is now about to perform the work on the log.
+		if strings.Contains(line, treeStateFile) {
+			oneshotStarted = true
+		}
+		// If we're in the interesting part of the strace output, then pass through the log line, otherwise
+		// just drop it.
+		if oneshotStarted {
+			_, _ = fmt.Fprintf(w, "%s\n", line)
+		}
+		// Check the stract log line against our list of interesting syscalls and update the info in
+		// our map.
+		for _, s := range syscalls {
+			if strings.Contains(line, s) {
+				c := m[s]
+				if !oneshotStarted {
+					// oneshot still hasn't fully started up, so we're going to skip all the early calls to this
+					// syscall.
+					c.First++
+				} else {
+					// oneshot is working on the log, so count this syscall invocation as being a candidate for
+					// fault injection.
+					c.N++
+				}
+				m[s] = c
+			}
+		}
+	}
+}
+
+// fsckLog runs fsck on the log rooted at the provided path.
+func fsckLog(t *testing.T, dir string) error {
+	t.Helper()
+
+	src := &client.FileFetcher{
+		Root: dir,
+	}
+	v, err := note.NewVerifier(testVerifier)
+	if err != nil {
+		klog.Exitf("Invalid verifier in %q: %v", testVerifier, err)
+	}
+	return fsck.Check(t.Context(), v.Name(), v, src, 1, defaultMerkleLeafHasher)
+}
+
+// defaultMerkleLeafHasher parses a C2SP tlog-tile bundle and returns the Merkle leaf hashes of each entry it contains.
+func defaultMerkleLeafHasher(bundle []byte) ([][]byte, error) {
+	eb := &api.EntryBundle{}
+	if err := eb.UnmarshalText(bundle); err != nil {
+		return nil, fmt.Errorf("unmarshal: %v", err)
+	}
+	r := make([][]byte, 0, len(eb.Entries))
+	for _, e := range eb.Entries {
+		h := rfc6962.DefaultHasher.HashLeaf(e)
+		r = append(r, h[:])
+	}
+	return r, nil
+}
+
+// mustWrite writes the provided contents to a file at the provided path, or causes a fatal test failure.
+func mustWrite(t *testing.T, path string, contents []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatalf("Failed to write %q: %v", path, err)
+	}
+}


### PR DESCRIPTION
This PR adds a fault-injection test for POSIX, using `strace` and `posix-oneshot` to try to cause tree corruption on disk.