### PR TITLE
Fix witness URL used for checkpoint for submission

### DIFF
--- a/internal/witness/witness_test.go
+++ b/internal/witness/witness_test.go
@@ -88,11 +88,11 @@ func TestWitnessGateway_Update(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wit1, err = tessera.NewWitness(wit1Vkey, baseURL)
+	wit1, err = tessera.NewWitness(wit1Vkey, baseURL.JoinPath("wit1"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	wit2, err = tessera.NewWitness(wit2Vkey, baseURL)
+	wit2, err = tessera.NewWitness(wit2Vkey, baseURL.JoinPath("wit2"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -423,11 +423,11 @@ func TestWitnessReusesProofs(t *testing.T) {
 	}))
 	baseURL := mustURL(t, ts.URL)
 	var err error
-	wit1, err = tessera.NewWitness(wit1Vkey, baseURL)
+	wit1, err = tessera.NewWitness(wit1Vkey, baseURL.JoinPath("wit1"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	wit2, err = tessera.NewWitness(wit2Vkey, baseURL)
+	wit2, err = tessera.NewWitness(wit2Vkey, baseURL.JoinPath("wit2"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/witness.go
+++ b/witness.go
@@ -16,8 +16,6 @@ package tessera
 
 import (
 	"bufio"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net/url"
@@ -189,16 +187,8 @@ func NewWitness(vkey string, witnessRoot *url.URL) (Witness, error) {
 	if err != nil {
 		return Witness{}, err
 	}
-	// "key hash" MUST be a lowercase hex-encoded SHA-256 hash of a 32-byte Ed25519 public key.
-	// This expression cuts off the identity name and hash.
-	key64 := strings.SplitAfterN(vkey, "+", 3)[2]
-	key, err := base64.StdEncoding.DecodeString(key64)
-	if err != nil {
-		return Witness{}, err
-	}
-	h := sha256.Sum256(key)
 
-	u := witnessRoot.JoinPath(fmt.Sprintf("/%x/add-checkpoint", h))
+	u := witnessRoot.JoinPath("/add-checkpoint")
 
 	return Witness{
 		Key: v,
@@ -298,4 +288,3 @@ func (wg WitnessGroup) Endpoints() map[string]note.Verifier {
 	}
 	return endpoints
 }
-

--- a/witness_test.go
+++ b/witness_test.go
@@ -19,14 +19,14 @@ const (
 )
 
 var (
-	bastion1, _ = url.Parse("https://b1.example.com/")
-	bastion2, _ = url.Parse("https://b2.example.com/")
-	wit1, _     = tessera.NewWitness(wit1_vkey, bastion1)
-	wit2, _     = tessera.NewWitness(wit2_vkey, bastion1)
-	wit3, _     = tessera.NewWitness(wit3_vkey, bastion2)
-	wit1Sign, _ = note.NewSigner(wit1_skey)
-	wit2Sign, _ = note.NewSigner(wit2_skey)
-	wit3Sign, _ = note.NewSigner(wit3_skey)
+	bastion, _   = url.Parse("https://b1.example.com/")
+	directURL, _ = url.Parse("https://witness.example.com/")
+	wit1, _      = tessera.NewWitness(wit1_vkey, bastion.JoinPath("wit1prefix"))
+	wit2, _      = tessera.NewWitness(wit2_vkey, bastion.JoinPath("wit2prefix"))
+	wit3, _      = tessera.NewWitness(wit3_vkey, directURL)
+	wit1Sign, _  = note.NewSigner(wit1_skey)
+	wit2Sign, _  = note.NewSigner(wit2_skey)
+	wit3Sign, _  = note.NewSigner(wit3_skey)
 )
 
 func TestWitnessGroup_Empty(t *testing.T) {
@@ -144,34 +144,34 @@ func TestWitnessGroup_URLs(t *testing.T) {
 		{
 			desc:         "witness 1",
 			group:        tessera.NewWitnessGroup(1, wit1),
-			expectedURLs: []string{"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add-checkpoint"},
+			expectedURLs: []string{"https://b1.example.com/wit1prefix/add-checkpoint"},
 		},
 		{
 			desc:         "witness 2",
 			group:        tessera.NewWitnessGroup(1, wit2),
-			expectedURLs: []string{"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add-checkpoint"},
+			expectedURLs: []string{"https://b1.example.com/wit2prefix/add-checkpoint"},
 		},
 		{
 			desc:         "witness 3",
 			group:        tessera.NewWitnessGroup(1, wit3),
-			expectedURLs: []string{"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add-checkpoint"},
+			expectedURLs: []string{"https://witness.example.com/add-checkpoint"},
 		},
 		{
 			desc:  "all witnesses in one group",
 			group: tessera.NewWitnessGroup(1, wit1, wit2, wit3),
 			expectedURLs: []string{
-				"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add-checkpoint",
-				"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add-checkpoint",
-				"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add-checkpoint",
+				"https://b1.example.com/wit1prefix/add-checkpoint",
+				"https://b1.example.com/wit2prefix/add-checkpoint",
+				"https://witness.example.com/add-checkpoint",
 			},
 		},
 		{
 			desc:  "all witnesses with duplicates in nests",
 			group: tessera.NewWitnessGroup(2, tessera.NewWitnessGroup(1, wit1, wit2), tessera.NewWitnessGroup(1, wit1, wit3)),
 			expectedURLs: []string{
-				"https://b1.example.com/b490a162bf632bdd72181cd9eb5b8ab8b13e4e973a9ce9a12a0810fd981bc186/add-checkpoint",
-				"https://b1.example.com/7a99cf3d04ea875d413c4b3fb70d74ef483efaf667eac56e35f0b96a112b1c84/add-checkpoint",
-				"https://b2.example.com/ae59f4e59ea1802501b6000f875f09eb49d267055d4a1df8b6d862edc004334c/add-checkpoint",
+				"https://b1.example.com/wit1prefix/add-checkpoint",
+				"https://b1.example.com/wit2prefix/add-checkpoint",
+				"https://witness.example.com/add-checkpoint",
 			},
 		},
 	}


### PR DESCRIPTION
This PR removes the assumption in the code that witnesses are always contacted via bastions.

Witnesses are now contacted directly on the URLs provided - if a witness is only contactable via a bastion, then the user must provide the URL on that bastion at which the witness is reachable.