### PR TITLE
Pass witness policy as []byte

### DIFF
--- a/witness.go
+++ b/witness.go
@@ -16,8 +16,8 @@ package tessera
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
-	"io"
 	"net/url"
 	"strconv"
 	"strings"
@@ -43,13 +43,13 @@ type policyComponent interface {
 }
 
 // NewWitnessGroupFromPolicy creates a graph of witness objects that represents the
-// policy provided via the reader, and which can be passed directly to the WithWitnesses
+// policy provided, and which can be passed directly to the WithWitnesses
 // appender lifecycle option.
 //
 // The policy must be structured as per the description in
 // https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/doc/policy.md
-func NewWitnessGroupFromPolicy(r io.Reader) (WitnessGroup, error) {
-	scanner := bufio.NewScanner(r)
+func NewWitnessGroupFromPolicy(p []byte) (WitnessGroup, error) {
+	scanner := bufio.NewScanner(bytes.NewBuffer(p))
 	components := make(map[string]policyComponent)
 
 	var quorumName string

--- a/witness_policy_test.go
+++ b/witness_policy_test.go
@@ -26,8 +26,7 @@ witness w2 example.com+3753d3de+AebBhMcghIUoavZpjuDofa4sW6fYHyVn7gvwDBfvkvuM htt
 group g1 all w1 w2
 quorum g1
 `
-	r := strings.NewReader(policy)
-	wg, err := NewWitnessGroupFromPolicy(r)
+	wg, err := NewWitnessGroupFromPolicy([]byte(policy))
 	if err != nil {
 		t.Fatalf("NewWitnessGroupFromPolicy() failed: %v", err)
 	}
@@ -83,8 +82,7 @@ quorum g1
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			r := strings.NewReader(tc.policy)
-			wg, err := NewWitnessGroupFromPolicy(r)
+			wg, err := NewWitnessGroupFromPolicy([]byte(tc.policy))
 			if err != nil {
 				t.Fatalf("NewWitnessGroupFromPolicy() failed: %v", err)
 			}
@@ -139,8 +137,7 @@ func TestNewWitnessGroupFromPolicy_Errors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			r := strings.NewReader(tc.policy)
-			_, err := NewWitnessGroupFromPolicy(r)
+			_, err := NewWitnessGroupFromPolicy([]byte(tc.policy))
 			if err == nil {
 				t.Fatal("Expected error, got nil")
 			}


### PR DESCRIPTION
Use a simple `[]byte` to pass the policy in, there's not much benefit to using an `io.Reader` as the policy is tiny.