### PR TITLE
Add throughput and ETA stats to fsck UI

### DIFF
--- a/cmd/fsck/tui/fsck_panel.go
+++ b/cmd/fsck/tui/fsck_panel.go
@@ -25,7 +25,9 @@ import (
 
 // NewFsckPanel creates a new TUI panel showing information about an ongoing fsck operation.
 func NewFsckPanel() *FsckPanel {
-	r := &FsckPanel{}
+	r := &FsckPanel{
+		statsView: NewStatsView(),
+	}
 	return r
 }
 
@@ -36,6 +38,8 @@ type FsckPanel struct {
 	// titlesBars is the list status/progress bars representing progress through the various levels of tiles in the log.
 	// The zeroth entry corresponds to the tiles on level zero.
 	tilesBars []*LayerProgressModel
+
+	statsView *StatsViewModel
 
 	// width is the width of the app window
 	width int
@@ -90,6 +94,9 @@ func (m *FsckPanel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
+		_, cmd = m.statsView.Update(StatsViewUpdateMsg{Status: msg.Status})
+		cmds = append(cmds, cmd)
+
 		return m, tea.Batch(cmds...)
 	default:
 		return m, nil
@@ -108,6 +115,7 @@ func (m *FsckPanel) View() string {
 		bars = append(bars, m.entriesBar.View())
 	}
 	bars = append(bars, LayerProgressKey())
+	bars = append(bars, lipgloss.NewStyle().Align(lipgloss.Left).Render(m.statsView.View()))
 	barsView := lipgloss.JoinVertical(lipgloss.Bottom, bars...)
 
 	content := lipgloss.NewStyle().

--- a/cmd/fsck/tui/fsck_panel.go
+++ b/cmd/fsck/tui/fsck_panel.go
@@ -115,17 +115,19 @@ func (m *FsckPanel) View() string {
 		bars = append(bars, m.entriesBar.View())
 	}
 	bars = append(bars, LayerProgressKey())
-	bars = append(bars, lipgloss.NewStyle().Align(lipgloss.Left).Render(m.statsView.View()))
 	barsView := lipgloss.JoinVertical(lipgloss.Bottom, bars...)
 
-	content := lipgloss.NewStyle().
+	progress := lipgloss.NewStyle().
 		Width(m.width).
 		Height(lipgloss.Height(barsView)+1).
-		Align(lipgloss.Center, lipgloss.Top).
 		Border(lipgloss.NormalBorder(), true, false, false, false).
 		Render(barsView)
 
-	return lipgloss.JoinVertical(lipgloss.Top, content)
+	stats := lipgloss.NewStyle().Align(lipgloss.Left).Render(m.statsView.View())
+
+	return lipgloss.NewStyle().Align(lipgloss.Center).Render(
+		lipgloss.JoinVertical(lipgloss.Top, progress, stats),
+	)
 }
 
 // FsckPanelUpdateMsg is used to tell the FsckPanel about updated status from the fsck operation.

--- a/cmd/fsck/tui/fsck_panel.go
+++ b/cmd/fsck/tui/fsck_panel.go
@@ -94,7 +94,7 @@ func (m *FsckPanel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 
-		_, cmd = m.statsView.Update(StatsViewUpdateMsg{Status: msg.Status})
+		_, cmd = m.statsView.Update(msg)
 		cmds = append(cmds, cmd)
 
 		return m, tea.Batch(cmds...)

--- a/cmd/fsck/tui/stats_view.go
+++ b/cmd/fsck/tui/stats_view.go
@@ -1,0 +1,110 @@
+// Copyright 2025 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tui
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/transparency-dev/tessera/fsck"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	movingaverage "github.com/RobinUS2/golang-moving-average"
+)
+
+type StatsViewUpdateMsg struct {
+	Status fsck.Status
+}
+
+// NewStatsView returns a widet which displays fsck statistics.
+func NewStatsView() *StatsViewModel {
+	m := &StatsViewModel{
+		bytesAvg:     movingaverage.New(10),
+		resourcesAvg: movingaverage.New(10),
+		errorsAvg:    movingaverage.New(10),
+	}
+	return m
+}
+
+// StatsViewModel is the UI model for a stats widget.
+type StatsViewModel struct {
+	// width available to this component.
+	width int
+
+	totalBytes     uint64
+	totalResources uint64
+	totalErrors    uint64
+
+	bytesAvg     *movingaverage.MovingAverage
+	resourcesAvg *movingaverage.MovingAverage
+	errorsAvg    *movingaverage.MovingAverage
+
+	lastUpdate time.Time
+	eta        time.Duration
+}
+
+func (m *StatsViewModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update is used to update the widget.
+func (m *StatsViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+	case StatsViewUpdateMsg:
+		now := time.Now()
+		d := now.Sub(m.lastUpdate)
+		m.lastUpdate = now
+
+		b := msg.Status.BytesFetched
+		r := msg.Status.ResourcesFetched
+		e := msg.Status.ErrorsEncountered
+		m.totalBytes += b
+		m.totalResources += r
+		m.totalErrors += e
+		m.bytesAvg.Add(float64(b) / d.Seconds())
+		m.resourcesAvg.Add(float64(r) / d.Seconds())
+		m.errorsAvg.Add(float64(e) / d.Seconds())
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+func (m *StatsViewModel) View() string {
+	// Render the pieces
+
+	bytesFetched := lipgloss.NewStyle().Width(27).Render(fmt.Sprintf("Bytes: %s (%s/s)", humanize.Bytes(m.totalBytes), humanize.Bytes(uint64(m.bytesAvg.Avg()))))
+	rSI, rP := humanize.ComputeSI(float64(m.totalResources))
+	rAvgSI, rAvgP := humanize.ComputeSI(float64(m.resourcesAvg.Avg()))
+	resourcesFetched := lipgloss.NewStyle().Width(28).Render(fmt.Sprintf("Resources: %03.1f %s (%03.1f%s/s)", rSI, rP, rAvgSI, rAvgP))
+	eSI, eP := humanize.ComputeSI(float64(m.totalErrors))
+	eAvgSI, eAvgP := humanize.ComputeSI(float64(m.errorsAvg.Avg()))
+	errorsEncountered := lipgloss.NewStyle().Width(20).Render(fmt.Sprintf("Errors: %03.1f %s (%03.1f%s/s)", eSI, eP, eAvgSI, eAvgP))
+
+	return lipgloss.NewStyle().
+		Width(m.width).Render(
+		lipgloss.JoinHorizontal(
+			lipgloss.Right,
+			bytesFetched,
+			resourcesFetched,
+			errorsEncountered),
+	)
+}

--- a/fsck/fsck.go
+++ b/fsck/fsck.go
@@ -44,10 +44,12 @@ type Fetcher interface {
 type Fsck struct {
 	origin       string
 	verifier     note.Verifier
-	fetcher      Fetcher
+	fetcher      *countingFetcher
 	bundleHasher func([]byte) ([][]byte, error)
 	rangeTracker *rangeTracker
 	opts         Opts
+
+	fsckTree *fsckTree
 }
 
 type Opts struct {
@@ -72,13 +74,15 @@ func New(origin string, verifier note.Verifier, f Fetcher, bundleHasher func([]b
 	return &Fsck{
 		origin:       origin,
 		verifier:     verifier,
-		fetcher:      f,
+		fetcher:      newCountingFetcher(f),
 		opts:         opts,
 		bundleHasher: bundleHasher,
 	}
 }
 
 // Check performs an integrity check against the log.
+//
+// Check may only be called once per instance of Fsck.
 func (f *Fsck) Check(ctx context.Context) error {
 	cp, cpRaw, _, err := client.FetchCheckpoint(ctx, f.fetcher.ReadCheckpoint, f.verifier, f.origin)
 	if err != nil {
@@ -90,7 +94,7 @@ func (f *Fsck) Check(ctx context.Context) error {
 
 	f.rangeTracker = newRangeTracker(cp.Size)
 
-	fTree := fsckTree{
+	f.fsckTree = &fsckTree{
 		fetcher:           f.fetcher,
 		bundleHasher:      f.bundleHasher,
 		tree:              (&compact.RangeFactory{Hash: rfc6962.DefaultHasher.HashChildren}).NewEmptyRange(0),
@@ -106,17 +110,17 @@ func (f *Fsck) Check(ctx context.Context) error {
 
 	// Kick off resource comparing workers
 	for range f.opts.N {
-		eg.Go(fTree.resourceCheckWorker(ctx))
+		eg.Go(f.fsckTree.resourceCheckWorker(ctx))
 	}
 
 	trackBundle := func(ctx context.Context, idx uint64, p uint8) ([]byte, error) {
-		fTree.rangeTracker.Update(-1, idx, Fetching)
+		f.fsckTree.rangeTracker.Update(-1, idx, Fetching)
 		r, err := f.fetcher.ReadEntryBundle(ctx, idx, p)
 		if err != nil {
-			fTree.rangeTracker.Update(-1, idx, FetchError)
+			f.fsckTree.rangeTracker.Update(-1, idx, FetchError)
 			return nil, err
 		}
-		fTree.rangeTracker.Update(-1, idx, Fetched)
+		f.fsckTree.rangeTracker.Update(-1, idx, Fetched)
 		return r, nil
 	}
 
@@ -127,19 +131,19 @@ func (f *Fsck) Check(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("error while streaming bundles: %v", err)
 		}
-		fTree.rangeTracker.Update(-1, b.RangeInfo.Index, OK)
-		if err := fTree.AppendBundle(b.RangeInfo, b.Data); err != nil {
+		f.fsckTree.rangeTracker.Update(-1, b.RangeInfo.Index, OK)
+		if err := f.fsckTree.AppendBundle(b.RangeInfo, b.Data); err != nil {
 			return fmt.Errorf("failure calling AppendBundle(%v): %v", b.RangeInfo, err)
 		}
-		if fTree.tree.End() >= cp.Size {
+		if f.fsckTree.tree.End() >= cp.Size {
 			break
 		}
 	}
 
 	// Ensure we see process any partial tiles too.
-	fTree.flushPartialTiles()
+	f.fsckTree.flushPartialTiles()
 	// Signal that there will be no more resource checking jobs coming so workers can exit when the channel is drained.
-	close(fTree.expectedResources)
+	close(f.fsckTree.expectedResources)
 
 	// Wait for all the work to be done.
 	if err := eg.Wait(); err != nil {
@@ -147,7 +151,7 @@ func (f *Fsck) Check(ctx context.Context) error {
 	}
 
 	// Finally, check that the claimed root hash matches what we calculated.
-	gotRoot, err := fTree.GetRootHash()
+	gotRoot, err := f.fsckTree.GetRootHash()
 	switch {
 	case err != nil:
 		return fmt.Errorf("failed to calculate root: %v", err)
@@ -163,6 +167,10 @@ func (f *Fsck) Check(ctx context.Context) error {
 type Status struct {
 	EntryRanges []Range
 	TileRanges  [][]Range
+
+	BytesFetched      uint64
+	ResourcesFetched  uint64
+	ErrorsEncountered uint64
 }
 
 func (f *Fsck) Status() Status {
@@ -171,8 +179,11 @@ func (f *Fsck) Status() Status {
 	}
 	e, t := f.rangeTracker.Ranges()
 	r := Status{
-		EntryRanges: e,
-		TileRanges:  t,
+		EntryRanges:       e,
+		TileRanges:        t,
+		BytesFetched:      f.fsckTree.fetcher.bytesFetched.Swap(0),
+		ResourcesFetched:  f.fsckTree.fetcher.resourcesFetched.Swap(0),
+		ErrorsEncountered: f.fsckTree.fetcher.errorsEncountered.Swap(0),
 	}
 	return r
 }
@@ -206,7 +217,7 @@ type resource struct {
 // fsckTree represents the tree we're currently checking.
 type fsckTree struct {
 	// fetcher knows how to retrieve static tlog-tile resources.
-	fetcher Fetcher
+	fetcher *countingFetcher
 	// bundleHasher knows how to convert entry bundles into leaf hashes.
 	bundleHasher func([]byte) ([][]byte, error)
 	// tree contains the running state of the leaves we've appended so far.
@@ -331,4 +342,40 @@ func (f *fsckTree) resourceCheckWorker(ctx context.Context) func() error {
 		}
 		return nil
 	}
+}
+
+// countingFetcher is a Fetcher which keeps track of the total number of bytes and resources fetched.
+type countingFetcher struct {
+	f                 Fetcher
+	bytesFetched      atomic.Uint64
+	resourcesFetched  atomic.Uint64
+	errorsEncountered atomic.Uint64
+}
+
+func newCountingFetcher(f Fetcher) *countingFetcher {
+	return &countingFetcher{
+		f: f,
+	}
+}
+
+func (c *countingFetcher) count(r []byte, err error) ([]byte, error) {
+	if err != nil {
+		c.errorsEncountered.Add(1)
+		return nil, err
+	}
+	c.bytesFetched.Add(uint64(len(r)))
+	c.resourcesFetched.Add(1)
+	return r, nil
+}
+
+func (c *countingFetcher) ReadCheckpoint(ctx context.Context) ([]byte, error) {
+	return c.count(c.f.ReadCheckpoint(ctx))
+}
+
+func (c *countingFetcher) ReadEntryBundle(ctx context.Context, i uint64, p uint8) ([]byte, error) {
+	return c.count(c.f.ReadEntryBundle(ctx, i, p))
+}
+
+func (c *countingFetcher) ReadTile(ctx context.Context, l, i uint64, p uint8) ([]byte, error) {
+	return c.count(c.f.ReadTile(ctx, l, i, p))
 }

--- a/fsck/fsck.go
+++ b/fsck/fsck.go
@@ -164,15 +164,23 @@ func (f *Fsck) Check(ctx context.Context) error {
 	return nil
 }
 
+// Status represents the current status of an ongoing fsck check.
 type Status struct {
+	// EntryRanges describes the status of the entrybundles in the target log.
 	EntryRanges []Range
-	TileRanges  [][]Range
+	// TileRanges describes the status of the tiles in the target log.
+	// The zeroth entry in the slice represents the lower-most tile level, just above the entry bundles.
+	TileRanges [][]Range
 
-	BytesFetched      uint64
-	ResourcesFetched  uint64
+	// BytesFetched is the total number of bytes fetched from the target log since the last time Status() was called.
+	BytesFetched uint64
+	// ResourcesFetched is the total number of resources fetched from the target log since the last time Status() was called.
+	ResourcesFetched uint64
+	// ErrorsEncountered is the total number of errors encountered since the last time Status() was called.
 	ErrorsEncountered uint64
 }
 
+// Status returns a struct representing the current status of the fsck operation.
 func (f *Fsck) Status() Status {
 	if f.rangeTracker == nil {
 		return Status{}

--- a/fsck/fsck_test.go
+++ b/fsck/fsck_test.go
@@ -65,9 +65,9 @@ func TestTrimFullToPartial(t *testing.T) {
 
 			f := &fsckTree{
 				expectedResources: make(chan resource, 1),
-				fetcher: &fakeFetcher{
+				fetcher: newCountingFetcher(&fakeFetcher{
 					tile: test.storedTile,
-				},
+				}),
 				rangeTracker: newRangeTracker(1),
 			}
 


### PR DESCRIPTION
This PR adds another line to the fsck TUI, showing the total and avg throughput (bytes, resources, and errors) along with an ETA.

![progress](https://github.com/user-attachments/assets/7d06ffbb-acf6-4e2d-a1ef-7c848b58fb34)
