### PR TITLE
fix missing env var in example in readme

### DIFF
--- a/cmd/examples/posix-oneshot/README.md
+++ b/cmd/examples/posix-oneshot/README.md
@@ -7,19 +7,16 @@
 The commands below create a new log and add entries to it, and then show a few approaches to inspect the contents of the log.
 
 ```shell
-# Set the keys via environment variables
+# Set the keys via environment variables, and a local directory where our demo log will be built.
 export LOG_PRIVATE_KEY="PRIVATE+KEY+example.com/log/testdata+33d7b496+AeymY/SZAX0jZcJ8enZ5FY1Dz+wTML2yWSkK+9DSF3eg"
 export LOG_PUBLIC_KEY="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
+export LOG_DIR="/tmp/tlog"
 
 # Create files containing new leaves to add
 mkdir /tmp/stuff
 echo "foo" > /tmp/stuff/foo
 echo "bar" > /tmp/stuff/bar
 echo "baz" > /tmp/stuff/baz
-
-# Make a blank dir where we'll store the log data
-export LOG_DIR="/tmp/tlog"
-mkdir "$LOG_DIR"
 
 # Integrate all of these leaves into the tree
 go run ./cmd/examples/posix-oneshot --storage_dir=${LOG_DIR} --entries="/tmp/stuff/*"

--- a/cmd/examples/posix-oneshot/README.md
+++ b/cmd/examples/posix-oneshot/README.md
@@ -17,6 +17,10 @@ echo "foo" > /tmp/stuff/foo
 echo "bar" > /tmp/stuff/bar
 echo "baz" > /tmp/stuff/baz
 
+# Make a blank dir where we'll store the log data
+export LOG_DIR="/tmp/tlog"
+mkdir "$LOG_DIR"
+
 # Integrate all of these leaves into the tree
 go run ./cmd/examples/posix-oneshot --storage_dir=${LOG_DIR} --entries="/tmp/stuff/*"
 


### PR DESCRIPTION
Set the "LOG_DIR" var (already used in the example script) to a simple dummy value which is likely to work, so that the example script as a whole now fully runs with no modification needed.

(Every other detail was already fully copy-pasta friendly -- well done and thank you, author of that! -- so I thought I'd put on the finishing touch.)