### PR TITLE
Implement MVP mirror support in append lifecycle

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -15,6 +15,7 @@
 package tessera
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -30,6 +31,7 @@ import (
 	f_log "github.com/transparency-dev/formats/log"
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api/layout"
+	m_gateway "github.com/transparency-dev/tessera/internal/mirror/gateway"
 	"github.com/transparency-dev/tessera/internal/otel"
 	"github.com/transparency-dev/tessera/internal/parse"
 	"github.com/transparency-dev/tessera/internal/witness"
@@ -745,7 +747,22 @@ func (o *AppendOptions) WithAntispam(inMemEntries uint, as Antispam) *AppendOpti
 }
 
 // CheckpointPublisher returns a function which should be used to create, sign, and potentially witness a new checkpoint.
+// Deprecated: Use CheckpointPublisherContex.
 func (o AppendOptions) CheckpointPublisher(lr LogReader, httpClient *http.Client) func(context.Context, uint64, []byte) ([]byte, error) {
+	return func(ctx context.Context, size uint64, root []byte) ([]byte, error) {
+		return o.CheckpointPublisherContext(ctx, lr, httpClient)(ctx, size, root)
+	}
+}
+
+// CheckpointPublisherContext returns a function which should be used to create, sign, and potentially witness a new checkpoint.
+func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogReader, httpClient *http.Client) func(context.Context, uint64, []byte) ([]byte, error) {
+	gw := sync.OnceValue(func() *m_gateway.Gateway {
+		if len(o.mirrors.Components) > 0 {
+			return m_gateway.NewGateway(ctx, httpClient, o.mirrors, lr, o.primarySigner.Name())
+		}
+		return nil
+	})
+
 	return func(ctx context.Context, size uint64, root []byte) ([]byte, error) {
 		return otel.Trace(ctx, "tessera.CheckpointPublisher", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
 			cp, err := o.newCP(ctx, size, root)
@@ -763,8 +780,13 @@ func (o AppendOptions) CheckpointPublisher(lr LogReader, httpClient *http.Client
 				return err
 			})
 			eg.Go(func() error {
+				if gw == nil {
+					return nil
+				}
+				mirrorCtx, cancel := context.WithTimeout(ctx, o.mirrorOpts.Timeout)
+				defer cancel()
 				var err error
-				ms, err = mirrorCheckpoint(ctx, cp, size, o.mirrors, lr, httpClient, o.mirrorOpts)
+				ms, err = mirrorCheckpoint(mirrorCtx, gw, &o.mirrors, cp, size, o.mirrorOpts.FailOpen)
 				return err
 			})
 
@@ -827,15 +849,38 @@ func witnessCheckpoint(ctx context.Context, cp []byte, cpSize uint64, witnesses 
 	})
 }
 
-// mirrorCheckpoint takes care of mirroring the given checkpoint with the provided mirror policy.
-// Returns signatures from mirrors, ready to append to the checkpoint, or an error.
-func mirrorCheckpoint(ctx context.Context, cp []byte, cpSize uint64, mirrors WitnessGroup, lr LogReader, httpClient *http.Client, opts MirroringOptions) ([]byte, error) {
-	return otel.Trace(ctx, "tessera.mirrorCheckpoint", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
-		if len(mirrors.Components) == 0 {
-			return nil, nil
+func mirrorCheckpoint(ctx context.Context, gw *m_gateway.Gateway, policy *WitnessGroup, cp []byte, size uint64, failOpen bool) ([]byte, error) {
+	// TODO(al): Add metrics
+	checkPolicy := func(sigs []byte) ([]byte, error) {
+		newCP := append(slices.Clone(cp), sigs...)
+		if policy.Satisfied(newCP) {
+			return sigs, nil
 		}
-		span.AddEvent("Starting mirroring")
-		return nil, nil
+		if failOpen {
+			slog.WarnContext(ctx, "MirrorGateway: policy not met, failing-open")
+			return sigs, nil
+		}
+		return sigs, fmt.Errorf("MirrorGateway: policy not met")
+	}
+
+	return otel.Trace(ctx, "tessera.mirrorCheckpoint", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
+		sigCh := gw.CosignCheckpoint(ctx, cp, size)
+		var sigBlock bytes.Buffer
+		for {
+			select {
+			case <-ctx.Done():
+				return checkPolicy(sigBlock.Bytes())
+			case sig, ok := <-sigCh:
+				if !ok {
+					return checkPolicy(sigBlock.Bytes())
+				}
+				sigBlock.Write(sig)
+				newCP := append(slices.Clone(cp), sigBlock.Bytes()...)
+				if policy.Satisfied(newCP) {
+					return sigBlock.Bytes(), nil
+				}
+			}
+		}
 	})
 }
 

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"sync"
@@ -746,8 +748,21 @@ func (o *AppendOptions) WithAntispam(inMemEntries uint, as Antispam) *AppendOpti
 	return o
 }
 
+// parseURLs converts a list of URL strings to a list of *url.URL, failing if any cannot be parsed.
+func parseURLs(us []string) ([]*url.URL, error) {
+	ret := make([]*url.URL, 0, len(us))
+	for _, s := range us {
+		u, err := url.Parse(s)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, u)
+	}
+	return ret, nil
+}
+
 // CheckpointPublisher returns a function which should be used to create, sign, and potentially witness a new checkpoint.
-// Deprecated: Use CheckpointPublisherContex.
+// Deprecated: Use CheckpointPublisherContext.
 func (o AppendOptions) CheckpointPublisher(lr LogReader, httpClient *http.Client) func(context.Context, uint64, []byte) ([]byte, error) {
 	return func(ctx context.Context, size uint64, root []byte) ([]byte, error) {
 		return o.CheckpointPublisherContext(ctx, lr, httpClient)(ctx, size, root)
@@ -756,13 +771,36 @@ func (o AppendOptions) CheckpointPublisher(lr LogReader, httpClient *http.Client
 
 // CheckpointPublisherContext returns a function which should be used to create, sign, and potentially witness a new checkpoint.
 func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogReader, httpClient *http.Client) func(context.Context, uint64, []byte) ([]byte, error) {
-	gw := sync.OnceValue(func() *m_gateway.Gateway {
-		if len(o.mirrors.Components) > 0 {
-			return m_gateway.NewGateway(ctx, httpClient, o.mirrors, lr, o.primarySigner.Name())
-		}
-		return nil
-	})
+	// TODO(al): Need a better way of surfacing errors. Maybe add a validate() func to AppendOptions?
+	var (
+		mirrorURLs []*url.URL
+		gw         *m_gateway.Gateway
+		err        error
+	)
 
+	sync.OnceFunc(func() {
+		mirrorURLs, err = parseURLs(slices.Collect(maps.Keys(o.mirrors.WitnessEndpoints())))
+		if err != nil {
+			err = fmt.Errorf("failed to parse mirror URLs: %w", err)
+			return
+		}
+		gw, err = m_gateway.NewGateway(ctx, m_gateway.Options{
+			Mirrors:   mirrorURLs,
+			LogReader: lr,
+			LogOrigin: o.primarySigner.Name(),
+		})
+		if err != nil {
+			err = fmt.Errorf("failed to create gateway: %w", err)
+			return
+		}
+	})
+	if err != nil {
+		return func(_ context.Context, _ uint64, _ []byte) ([]byte, error) {
+			return nil, fmt.Errorf("failed to parse mirror URLs: %w", err)
+		}
+	}
+
+	// Now return the actual publisher func.
 	return func(ctx context.Context, size uint64, root []byte) ([]byte, error) {
 		return otel.Trace(ctx, "tessera.CheckpointPublisher", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
 			cp, err := o.newCP(ctx, size, root)

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -764,40 +764,36 @@ func parseURLs(us []string) ([]*url.URL, error) {
 // CheckpointPublisher returns a function which should be used to create, sign, and potentially witness a new checkpoint.
 // Deprecated: Use CheckpointPublisherContext.
 func (o AppendOptions) CheckpointPublisher(lr LogReader, httpClient *http.Client) func(context.Context, uint64, []byte) ([]byte, error) {
+	var (
+		once sync.Once
+		f    func(context.Context, uint64, []byte) ([]byte, error)
+		err  error
+	)
 	return func(ctx context.Context, size uint64, root []byte) ([]byte, error) {
-		return o.CheckpointPublisherContext(ctx, lr, httpClient)(ctx, size, root)
+		// Only delegate once.
+		once.Do(func() {
+			f, err = o.CheckpointPublisherContext(ctx, lr, httpClient)
+		})
+		if err != nil {
+			return nil, err
+		}
+		return f(ctx, size, root)
 	}
 }
 
 // CheckpointPublisherContext returns a function which should be used to create, sign, and potentially witness a new checkpoint.
-func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogReader, httpClient *http.Client) func(context.Context, uint64, []byte) ([]byte, error) {
-	// TODO(al): Need a better way of surfacing errors. Maybe add a validate() func to AppendOptions?
-	var (
-		mirrorURLs []*url.URL
-		gw         *m_gateway.Gateway
-		err        error
-	)
-
-	sync.OnceFunc(func() {
-		mirrorURLs, err = parseURLs(slices.Collect(maps.Keys(o.mirrors.WitnessEndpoints())))
-		if err != nil {
-			err = fmt.Errorf("failed to parse mirror URLs: %w", err)
-			return
-		}
-		gw, err = m_gateway.NewGateway(ctx, m_gateway.Options{
-			Mirrors:   mirrorURLs,
-			LogReader: lr,
-			LogOrigin: o.primarySigner.Name(),
-		})
-		if err != nil {
-			err = fmt.Errorf("failed to create gateway: %w", err)
-			return
-		}
+func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogReader, httpClient *http.Client) (func(context.Context, uint64, []byte) ([]byte, error), error) {
+	mirrorURLs, err := parseURLs(slices.Collect(maps.Keys(o.mirrors.WitnessEndpoints())))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse mirror URLs: %w", err)
+	}
+	gw, err := m_gateway.NewGateway(ctx, m_gateway.Options{
+		Mirrors:   mirrorURLs,
+		LogReader: lr,
+		LogOrigin: o.primarySigner.Name(),
 	})
 	if err != nil {
-		return func(_ context.Context, _ uint64, _ []byte) ([]byte, error) {
-			return nil, fmt.Errorf("failed to parse mirror URLs: %w", err)
-		}
+		return nil, fmt.Errorf("failed to create gateway: %w", err)
 	}
 
 	// Now return the actual publisher func.
@@ -835,7 +831,7 @@ func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogRea
 			cp = append(append(slices.Clone(cp), ws...), ms...)
 			return cp, nil
 		})
-	}
+	}, nil
 }
 
 // witnessCheckpoint takes care of witnessing the given checkpoint with the provided witness policy.

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -761,39 +761,17 @@ func parseURLs(us []string) ([]*url.URL, error) {
 	return ret, nil
 }
 
-// CheckpointPublisher returns a function which should be used to create, sign, and potentially witness a new checkpoint.
+// CheckpointPublisher should not be used.
 // Deprecated: Use CheckpointPublisherContext.
 func (o AppendOptions) CheckpointPublisher(lr LogReader, httpClient *http.Client) func(context.Context, uint64, []byte) ([]byte, error) {
-	var (
-		once sync.Once
-		f    func(context.Context, uint64, []byte) ([]byte, error)
-		err  error
-	)
-	return func(ctx context.Context, size uint64, root []byte) ([]byte, error) {
-		// Only delegate once.
-		once.Do(func() {
-			f, err = o.CheckpointPublisherContext(ctx, lr, httpClient)
-		})
-		if err != nil {
-			return nil, err
-		}
-		return f(ctx, size, root)
-	}
+	panic("CheckpointPublisher is deprecated, Tessera should be using CheckpointPublisherContext instead.\nPlease file an issue if this has affected you.")
 }
 
-// CheckpointPublisherContext returns a function which should be used to create, sign, and potentially witness a new checkpoint.
+// CheckpointPublisherContext returns a function which should be used to create, sign, and potentially witness and/or mirror a new checkpoint.
 func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogReader, httpClient *http.Client) (func(context.Context, uint64, []byte) ([]byte, error), error) {
-	mirrorURLs, err := parseURLs(slices.Collect(maps.Keys(o.mirrors.WitnessEndpoints())))
+	mirrorGW, err := o.mirrorGateway(ctx, lr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse mirror URLs: %w", err)
-	}
-	gw, err := m_gateway.NewGateway(ctx, m_gateway.Options{
-		Mirrors:   mirrorURLs,
-		LogReader: lr,
-		LogOrigin: o.primarySigner.Name(),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create gateway: %w", err)
+		return nil, err
 	}
 
 	// Now return the actual publisher func.
@@ -813,16 +791,15 @@ func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogRea
 				ws, err = witnessCheckpoint(ctx, cp, size, o.witnesses, lr, httpClient, o.witnessOpts)
 				return err
 			})
-			eg.Go(func() error {
-				if gw == nil {
-					return nil
-				}
-				mirrorCtx, cancel := context.WithTimeout(ctx, o.mirrorOpts.Timeout)
-				defer cancel()
-				var err error
-				ms, err = mirrorCheckpoint(mirrorCtx, gw, &o.mirrors, cp, size, o.mirrorOpts.FailOpen)
-				return err
-			})
+			if mirrorGW != nil {
+				eg.Go(func() error {
+					mirrorCtx, cancel := context.WithTimeout(ctx, o.mirrorOpts.Timeout)
+					defer cancel()
+					var err error
+					ms, err = mirrorCheckpoint(mirrorCtx, cp, size, mirrorGW, &o.mirrors, o.mirrorOpts.FailOpen)
+					return err
+				})
+			}
 
 			if err := eg.Wait(); err != nil {
 				return nil, fmt.Errorf("failed to fetch cosignatures: %v", err)
@@ -832,6 +809,27 @@ func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogRea
 			return cp, nil
 		})
 	}, nil
+}
+
+// mirrorGateway creates and returns a mirrorGateway instance, or nil if no mirrors are configured.
+func (o AppendOptions) mirrorGateway(ctx context.Context, lr LogReader) (*m_gateway.Gateway, error) {
+	mirrorURLs, err := parseURLs(slices.Collect(maps.Keys(o.mirrors.WitnessEndpoints())))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse mirror URLs: %w", err)
+	}
+	if len(mirrorURLs) == 0 {
+		return nil, nil
+	}
+
+	mirrorGateway, err := m_gateway.NewGateway(ctx, m_gateway.Options{
+		Mirrors:   mirrorURLs,
+		LogReader: lr,
+		LogOrigin: o.primarySigner.Name(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gateway: %w", err)
+	}
+	return mirrorGateway, nil
 }
 
 // witnessCheckpoint takes care of witnessing the given checkpoint with the provided witness policy.
@@ -883,35 +881,35 @@ func witnessCheckpoint(ctx context.Context, cp []byte, cpSize uint64, witnesses 
 	})
 }
 
-func mirrorCheckpoint(ctx context.Context, gw *m_gateway.Gateway, policy *WitnessGroup, cp []byte, size uint64, failOpen bool) ([]byte, error) {
+func mirrorCheckpoint(ctx context.Context, cp []byte, cpSize uint64, gw *m_gateway.Gateway, policy *WitnessGroup, failOpen bool) ([]byte, error) {
 	// TODO(al): Add metrics
-	checkPolicy := func(sigs []byte) ([]byte, error) {
+	checkPolicy := func(sigs []byte, failOpen bool) ([]byte, error) {
 		newCP := append(slices.Clone(cp), sigs...)
-		if policy.Satisfied(newCP) {
-			return sigs, nil
+		if !policy.Satisfied(newCP) {
+			if failOpen {
+				slog.WarnContext(ctx, "MirrorGateway: policy not met, failing-open")
+				return sigs, nil
+			}
+			return sigs, fmt.Errorf("MirrorGateway: policy not met")
 		}
-		if failOpen {
-			slog.WarnContext(ctx, "MirrorGateway: policy not met, failing-open")
-			return sigs, nil
-		}
-		return sigs, fmt.Errorf("MirrorGateway: policy not met")
+		return sigs, nil
 	}
 
 	return otel.Trace(ctx, "tessera.mirrorCheckpoint", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
-		sigCh := gw.CosignCheckpoint(ctx, cp, size)
+		sigCh := gw.CosignCheckpoint(ctx, cp, cpSize)
 		var sigBlock bytes.Buffer
 		for {
 			select {
 			case <-ctx.Done():
-				return checkPolicy(sigBlock.Bytes())
+				return checkPolicy(sigBlock.Bytes(), failOpen)
 			case sig, ok := <-sigCh:
 				if !ok {
-					return checkPolicy(sigBlock.Bytes())
+					return checkPolicy(sigBlock.Bytes(), failOpen)
 				}
 				sigBlock.Write(sig)
-				newCP := append(slices.Clone(cp), sigBlock.Bytes()...)
-				if policy.Satisfied(newCP) {
-					return sigBlock.Bytes(), nil
+				// Don't allow failOpen here, or we'll break out of the collection loop prematurely.
+				if sigs, err := checkPolicy(sigBlock.Bytes(), false); err == nil {
+					return sigs, nil
 				}
 			}
 		}

--- a/append_lifecycle_test.go
+++ b/append_lifecycle_test.go
@@ -431,7 +431,10 @@ func TestCheckpointPublisher(t *testing.T) {
 
 			lr := newFakeLogReaderForTest(t)
 
-			publisher := test.opts.CheckpointPublisher(t.Context(), lr, client)
+			publisher, err := test.opts.CheckpointPublisherContext(t.Context(), lr, client)
+			if err != nil {
+				t.Fatalf("expected error %v but got: %v", test.expectErr, err)
+			}
 			cp, err := publisher(t.Context(), 5, []byte("12345678901234567890123456789012"))
 			if (err != nil) != test.expectErr {
 				t.Fatalf("expected error %v but got: %v", test.expectErr, err)

--- a/append_lifecycle_test.go
+++ b/append_lifecycle_test.go
@@ -15,17 +15,23 @@
 package tessera
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	f_note "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/witness/config"
 	"github.com/transparency-dev/witness/persistence/inmemory"
 	"github.com/transparency-dev/witness/witness"
@@ -286,6 +292,9 @@ func TestWithMirrors(t *testing.T) {
 const (
 	testWit1VKey = "Wit1+55ee4561+AVhZSmQj9+SoL+p/nN0Hh76xXmF7QcHfytUrI1XfSClk"
 	testWit1SKey = "PRIVATE+KEY+Wit1+55ee4561+AeadRiG7XM4XiieCHzD8lxysXMwcViy5nYsoXURWGrlE"
+
+	testMirrorVKey = "Mirror1+66ee4561+AVhZSmQj9+SoL+p/nN0Hh76xXmF7QcHfytUrI1XfSClk"
+	testMirrorSKey = "PRIVATE+KEY+Mirror1+66ee4561+AeadRiG7XM4XiieCHzD8lxysXMwcViy5nYsoXURWGrlE"
 )
 
 func newWitnessHandler(t *testing.T, logVerifier note.Verifier, witnessSKey string) http.HandlerFunc {
@@ -347,7 +356,23 @@ func TestCheckpointPublisher(t *testing.T) {
 		t.Fatalf("failed to create witness verifier: %v", err)
 	}
 
-	dummyMirrors := NewWitnessGroup(1, wit)
+	mirrorServer := httptest.NewServer(newMirrorHandler(t, testMirrorSKey))
+	t.Cleanup(mirrorServer.Close)
+
+	mirrorServerURL, err := url.Parse(mirrorServer.URL)
+	if err != nil {
+		t.Fatalf("failed to parse mirror server url: %v", err)
+	}
+
+	m, err := NewWitness(testMirrorVKey, mirrorServerURL)
+	if err != nil {
+		t.Fatalf("failed to create mirror: %v", err)
+	}
+	mirrors := NewWitnessGroup(1, m)
+	mirrorVerifier, err := f_note.NewVerifierForCosignatureV1(testMirrorVKey)
+	if err != nil {
+		t.Fatalf("failed to create mirror verifier: %v", err)
+	}
 
 	for _, test := range []struct {
 		desc               string
@@ -366,13 +391,14 @@ func TestCheckpointPublisher(t *testing.T) {
 			expectCosignatures: []note.Verifier{witVerifier},
 		},
 		{
-			desc: "mirrors only",
-			opts: NewAppendOptions().WithCheckpointSigner(logSigner).WithMirrors(dummyMirrors, nil),
+			desc:               "mirrors only",
+			opts:               NewAppendOptions().WithCheckpointSigner(logSigner).WithMirrors(mirrors, nil),
+			expectCosignatures: []note.Verifier{mirrorVerifier},
 		},
 		{
 			desc:               "witnesses and mirrors",
-			opts:               NewAppendOptions().WithCheckpointSigner(logSigner).WithWitnesses(witnesses, nil).WithMirrors(dummyMirrors, nil),
-			expectCosignatures: []note.Verifier{witVerifier},
+			opts:               NewAppendOptions().WithCheckpointSigner(logSigner).WithWitnesses(witnesses, nil).WithMirrors(mirrors, nil),
+			expectCosignatures: []note.Verifier{witVerifier, mirrorVerifier},
 		},
 		{
 			desc:         "witness fails, failOpen=false",
@@ -403,13 +429,9 @@ func TestCheckpointPublisher(t *testing.T) {
 				test.opts.WithWitnesses(failingWitnesses, wOpts)
 			}
 
-			lr := &fakeLogReader{
-				readCheckpoint: func(ctx context.Context) ([]byte, error) {
-					return nil, errors.New("no checkpoint yet")
-				},
-			}
+			lr := newFakeLogReaderForTest(t)
 
-			publisher := test.opts.CheckpointPublisher(lr, client)
+			publisher := test.opts.CheckpointPublisher(t.Context(), lr, client)
 			cp, err := publisher(t.Context(), 5, []byte("12345678901234567890123456789012"))
 			if (err != nil) != test.expectErr {
 				t.Fatalf("expected error %v but got: %v", test.expectErr, err)
@@ -432,5 +454,128 @@ func TestCheckpointPublisher(t *testing.T) {
 				t.Errorf("expected %d signatures, got %d", len(wantV), len(n.Sigs))
 			}
 		})
+	}
+}
+
+func newFakeLogReaderForTest(t *testing.T) *fakeLogReader {
+	hasher := rfc6962.DefaultHasher
+	entries := [][]byte{
+		[]byte("entry-0"),
+		[]byte("entry-1"),
+		[]byte("entry-2"),
+		[]byte("entry-3"),
+		[]byte("entry-4"),
+	}
+
+	h0 := hasher.HashLeaf(entries[0])
+	h1 := hasher.HashLeaf(entries[1])
+	h01 := hasher.HashChildren(h0, h1)
+	h2 := hasher.HashLeaf(entries[2])
+	h3 := hasher.HashLeaf(entries[3])
+	h23 := hasher.HashChildren(h2, h3)
+	h0123 := hasher.HashChildren(h01, h23)
+	h4 := hasher.HashLeaf(entries[4])
+
+	tileNodes := [][]byte{h0, h1, h01, h2, h3, h23, h0123, h4}
+	var tileBuf bytes.Buffer
+	for _, n := range tileNodes {
+		tileBuf.Write(n)
+	}
+	tileBytes := tileBuf.Bytes()
+
+	var bundleBuf bytes.Buffer
+	for _, entry := range entries {
+		_ = binary.Write(&bundleBuf, binary.BigEndian, uint16(len(entry)))
+		bundleBuf.Write(entry)
+	}
+	bundleBytes := bundleBuf.Bytes()
+
+	return &fakeLogReader{
+		readCheckpoint: func(ctx context.Context) ([]byte, error) {
+			return nil, os.ErrNotExist
+		},
+		readTile: func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+			if level == 0 && index == 0 {
+				return tileBytes, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		readEntryBundle: func(ctx context.Context, index uint64, p uint8) ([]byte, error) {
+			if index == 0 {
+				return bundleBytes, nil
+			}
+			return nil, os.ErrNotExist
+		},
+	}
+}
+
+func newMirrorHandler(t *testing.T, mirrorSKey string) http.HandlerFunc {
+	mirrorSigner, err := f_note.NewSignerForCosignatureV1(mirrorSKey)
+	if err != nil {
+		t.Fatalf("failed to create mirror signer: %v", err)
+	}
+	logVerifier, err := note.NewVerifier("example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx")
+	if err != nil {
+		t.Fatalf("failed to create log verifier: %v", err)
+	}
+
+	var mu sync.Mutex
+	var pendingCP []byte
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/add-checkpoint") {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			parts := bytes.SplitN(body, []byte("\n\n"), 2)
+			if len(parts) == 2 {
+				mu.Lock()
+				pendingCP = parts[1]
+				mu.Unlock()
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/add-entries") {
+			_, _ = io.Copy(io.Discard, r.Body)
+
+			mu.Lock()
+			cp := pendingCP
+			mu.Unlock()
+
+			if len(cp) == 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			// Open and parse the checkpoint note using log's verifier.
+			n, err := note.Open(cp, note.VerifierList(logVerifier))
+			if err != nil {
+				t.Errorf("failed to open checkpoint in mock mirror: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			// Sign it with the mirror signer.
+			signedNote, err := note.Sign(n, mirrorSigner)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			// Extract only the signature line we added.
+			idx := strings.Index(string(signedNote), "\n— "+mirrorSigner.Name()+" ")
+			if idx < 0 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			sigLine := string(signedNote)[idx+1:]
+
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(sigLine))
+			return
+		}
 	}
 }

--- a/cmd/conformance/posix/README.md
+++ b/cmd/conformance/posix/README.md
@@ -52,3 +52,15 @@ go run github.com/mhutchinson/woodpecker@main \
   --custom_log_origin=example.com/log/testdata \
   --custom_log_vkey=${LOG_PUBLIC_KEY}
 ```
+
+## Mirroring
+
+> [!WARNING]
+> Experimental feature, not subject to the SemVer policy!
+
+This binary supports mirroring the contents of the log to a [tlog-mirror](https://c2sp.org/tlog-mirror) compliant mirror,
+such as the one(s) under [cmd/mtc/mirror](/cmd/mtc/mirror).
+
+Pass the path to a configuration file in the [tlog-policy](https://c2sp.org/tlog-policy) format to the `--mirror_policy` flag
+to enable this feature.
+

--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -45,6 +45,7 @@ var (
 	additionalPrivateKeyFiles = []string{}
 	slogLevel                 = flag.Int("slog_level", 0, "The cut-off threshold for structured logging. Default is 0 (INFO). See https://pkg.go.dev/log/slog#Level for other levels.")
 	logFormat                 = flag.String("log_format", "text", "The format of the logs: text or json.")
+	mirrorPolicyFile          = flag.String("mirror_policy", "", "File containing the mirror policy in tlog-policy format. If unset, no mirroring will be performed.")
 )
 
 func init() {
@@ -93,12 +94,29 @@ func main() {
 		}
 	}
 
-	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, tessera.NewAppendOptions().
+	opts := tessera.NewAppendOptions().
 		WithCheckpointSigner(s, a...).
 		WithCheckpointInterval(time.Second).
 		WithCheckpointRepublishInterval(time.Minute).
 		WithBatching(256, time.Second).
-		WithAntispam(tessera.DefaultAntispamInMemorySize, antispam))
+		WithAntispam(tessera.DefaultAntispamInMemorySize, antispam)
+	if *mirrorPolicyFile != "" {
+		b, err := os.ReadFile(*mirrorPolicyFile)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to read mirror policy", slog.Any("error", err))
+			os.Exit(1)
+		}
+		policy, err := tessera.NewWitnessGroupFromPolicy(b)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to parse mirror policy", slog.Any("error", err))
+			os.Exit(1)
+		}
+		opts = opts.WithMirrors(policy, nil)
+		slog.InfoContext(ctx, "Mirroring enabled", slog.Any("policy", policy))
+	}
+
+	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, opts)
+
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create new appender", slog.Any("error", err))
 		os.Exit(1)
@@ -190,8 +208,8 @@ func getSignerOrDie() note.Signer {
 			os.Exit(1)
 		}
 	}
-	s, err := note.NewSigner(privKey)
-	if err != nil {
+	var s note.Signer
+	if s, err = note.NewSigner(privKey); err != nil {
 		slog.ErrorContext(context.Background(), "Failed to instantiate signer", slog.Any("error", err))
 		os.Exit(1)
 	}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -34,10 +34,12 @@ import (
 
 	"log/slog"
 
+	f_note "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tessera/client"
+
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/sync/errgroup"
 )
@@ -74,7 +76,7 @@ func TestMain(m *testing.M) {
 	}
 
 	var err error
-	noteVerifier, err = note.NewVerifier(*logPublicKey)
+	noteVerifier, err = f_note.NewVerifier(*logPublicKey)
 	if err != nil {
 		slog.ErrorContext(context.Background(), "Failed to create new verifier", slog.Any("error", err))
 		os.Exit(1)

--- a/internal/hammer/hammer.go
+++ b/internal/hammer/hammer.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/transparency-dev/tessera/client"
 	"github.com/transparency-dev/tessera/internal/hammer/loadtest"
-	"golang.org/x/mod/sumdb/note"
+	f_note "github.com/transparency-dev/formats/note"
 	"golang.org/x/net/http2"
 
 	"log/slog"
@@ -108,7 +108,7 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	logSigV, err := note.NewVerifier(*logPubKey)
+	logSigV, err := f_note.NewVerifier(*logPubKey)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to create verifier", slog.Any("error", err))
 		os.Exit(1)

--- a/internal/mirror/gateway/mirror_gateway.go
+++ b/internal/mirror/gateway/mirror_gateway.go
@@ -88,7 +88,7 @@ func NewGateway(ctx context.Context, opts Options) (*Gateway, error) {
 		return nil, fmt.Errorf("log reader is required")
 	}
 
-	g := &Gateway{
+	gw := &Gateway{
 		httpClient: opts.HTTPClient,
 		lr:         opts.LogReader,
 	}
@@ -118,13 +118,14 @@ func NewGateway(ctx context.Context, opts Options) (*Gateway, error) {
 			client: c,
 			goals:  make(chan goal, 1),
 		}
-		g.targets = append(g.targets, target)
-
-		// Start the worker goroutine.
-		go g.runWorker(ctx, target)
+		gw.targets = append(gw.targets, target)
+	}
+	// Start the workers
+	for _, target := range gw.targets {
+		go gw.runWorker(ctx, target)
 	}
 
-	return g, nil
+	return gw, nil
 }
 
 // CosignCheckpoint updates the goals for all mirrors and returns a channel over which
@@ -132,11 +133,11 @@ func NewGateway(ctx context.Context, opts Options) (*Gateway, error) {
 // The channel is closed once all mirrors' signatures have been sent or the context is canceled.
 //
 // It is strongly recommended that the context passed in here has a deadline or timeout set.
-func (g *Gateway) CosignCheckpoint(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
-	out := make(chan []byte, len(g.targets))
+func (gw *Gateway) CosignCheckpoint(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+	out := make(chan []byte, len(gw.targets))
 
 	// If there are no mirrors, return immediately.
-	if len(g.targets) == 0 {
+	if len(gw.targets) == 0 {
 		// Return a _closed_ channel, not `nil`, as callers will iterate over the
 		// returned channel and we don't want to block them forever.
 		close(out)
@@ -146,14 +147,14 @@ func (g *Gateway) CosignCheckpoint(ctx context.Context, cp []byte, cpSize uint64
 	N := &atomic.Uint32{}
 
 	// Send updated goals to each of the target workers.
-	for _, target := range g.targets {
+	for _, target := range gw.targets {
 		newGoal := goal{
 			cp:     cp,
 			cpSize: cpSize,
 			done: func(sig []byte, err error) {
 				// Last one out please turn off the lights.
 				defer func() {
-					if N.Add(1) == uint32(len(g.targets)) {
+					if N.Add(1) == uint32(len(gw.targets)) {
 						close(out)
 					}
 				}()
@@ -198,7 +199,7 @@ func (g *Gateway) CosignCheckpoint(ctx context.Context, cp []byte, cpSize uint64
 //
 // It will block on the goals channel until a goal is received, or the context is
 // cancelled.
-func (g *Gateway) runWorker(ctx context.Context, target *mirrorTarget) {
+func (gw *Gateway) runWorker(ctx context.Context, target *mirrorTarget) {
 	slog.InfoContext(ctx, "MirrorGateway: Starting worker", slog.String("url", target.url.String()))
 	defer slog.InfoContext(ctx, "MirrorGateway: Stopping worker", slog.String("url", target.url.String()))
 
@@ -206,21 +207,21 @@ func (g *Gateway) runWorker(ctx context.Context, target *mirrorTarget) {
 		select {
 		case <-ctx.Done():
 			return
-		case job, ok := <-target.goals:
+		case goal, ok := <-target.goals:
 			if !ok {
 				// Channel closed: down tools and exit.
 				return
 			}
 
 			// TODO(al): Consider making this timeout configurable. This should be fine for the moment though.
-			goalJob := g.chaseGoal(target, job, 1*time.Minute)
+			goalJob := gw.chaseGoalJob(target, goal, 1*time.Minute)
 			sigs, err := goalJob(ctx)
-			job.done(sigs, err)
+			goal.done(sigs, err)
 		}
 	}
 }
 
-func (g *Gateway) chaseGoal(target *mirrorTarget, job goal, timeout time.Duration) func(context.Context) ([]byte, error) {
+func (gw *Gateway) chaseGoalJob(target *mirrorTarget, job goal, timeout time.Duration) func(context.Context) ([]byte, error) {
 	return func(ctx context.Context) ([]byte, error) {
 		var rSigs []byte
 		var rErr error

--- a/internal/mirror/gateway/mirror_gateway.go
+++ b/internal/mirror/gateway/mirror_gateway.go
@@ -12,28 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package gateway contains a mirror gateway implementation which knows how to keep a pool of mirrors
+// up to date with a given log.
 package gateway
 
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"log/slog"
 
+	"github.com/transparency-dev/tessera/client"
 	"github.com/transparency-dev/tessera/client/mirror"
-	"golang.org/x/mod/sumdb/note"
 )
-
-// WitnessGroup defines the subset of tessera.WitnessGroup methods needed by the gateway.
-type WitnessGroup interface {
-	WitnessEndpoints() map[string][]note.Verifier
-}
 
 // LogReader defines the subset of tessera.LogReader methods needed by the gateway.
 type LogReader interface {
@@ -65,72 +60,61 @@ type Gateway struct {
 	targets    []*mirrorTarget
 }
 
+// Options represents the configuration for a Gateway.
+type Options struct {
+	// HTTPClient is the HTTP client to use for all HTTP operations, if nil uses the DefaultHTTPClient.
+	HTTPClient *http.Client
+	// Mirrors defines the pool of mirrors to update.
+	Mirrors []*url.URL
+	// LogReader provides access to the main log.
+	LogReader LogReader
+	// LogOrigin is the origin ID of the log.
+	LogOrigin string
+}
+
 // NewGateway creates a new Gateway that will keep mirrors up-to-date.
-func NewGateway(ctx context.Context, httpClient *http.Client, mirrors WitnessGroup, lr LogReader, logOrigin string) *Gateway {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+//
+// The provided context should be cancelled once the gateway is no-longer needed such that resources
+// associated with it are released, in particular this will cause all worker goroutines to terminate.
+func NewGateway(ctx context.Context, opts Options) (*Gateway, error) {
+	if opts.HTTPClient == nil {
+		slog.WarnContext(ctx, "MirrorGateway: No HTTP client configured, using DefaultHTTPClient")
+		opts.HTTPClient = http.DefaultClient
+	}
+	if opts.LogOrigin == "" {
+		return nil, fmt.Errorf("log origin is required")
+	}
+	if opts.LogReader == nil {
+		return nil, fmt.Errorf("log reader is required")
 	}
 
 	g := &Gateway{
-		httpClient: httpClient,
-		lr:         lr,
+		httpClient: opts.HTTPClient,
+		lr:         opts.LogReader,
 	}
 
-	endpoints := mirrors.WitnessEndpoints()
-	for u := range endpoints {
-		parsedURL, err := url.Parse(u)
+	endpoints := opts.Mirrors
+	for _, u := range endpoints {
+		mirrorFetcher, err := client.NewHTTPFetcher(u, opts.HTTPClient)
 		if err != nil {
-			slog.ErrorContext(ctx, "Invalid mirror URL", slog.String("url", u), slog.Any("error", err))
-			continue
-		}
-
-		tileFetcher := func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
-			return lr.ReadTile(ctx, level, index, p)
-		}
-		bundleFetcher := func(ctx context.Context, index uint64, p uint8) ([]byte, error) {
-			return lr.ReadEntryBundle(ctx, index, p)
-		}
-		mirrorCheckpointFetcher := func(ctx context.Context) ([]byte, error) {
-			checkpointURL, err := parsedURL.Parse("checkpoint")
-			if err != nil {
-				return nil, err
-			}
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, checkpointURL.String(), nil)
-			if err != nil {
-				return nil, err
-			}
-			resp, err := httpClient.Do(req)
-			if err != nil {
-				return nil, err
-			}
-			defer func() {
-				_ = resp.Body.Close()
-			}()
-			if resp.StatusCode == http.StatusNotFound {
-				return nil, os.ErrNotExist
-			}
-			if resp.StatusCode != http.StatusOK {
-				return nil, fmt.Errorf("failed to fetch checkpoint from mirror: status %d", resp.StatusCode)
-			}
-			return io.ReadAll(resp.Body)
+			return nil, fmt.Errorf("invalid mirror URL %v: %v", u, err)
 		}
 
 		mOpts := mirror.NewOptions().
-			WithMirrorURL(parsedURL).
-			WithHTTPClient(httpClient).
-			WithLogOrigin(logOrigin).
-			WithTileFetcher(tileFetcher).
-			WithBundleFetcher(bundleFetcher).
-			WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
+			WithMirrorURL(u).
+			WithHTTPClient(opts.HTTPClient).
+			WithLogOrigin(opts.LogOrigin).
+			WithTileFetcher(opts.LogReader.ReadTile).
+			WithBundleFetcher(opts.LogReader.ReadEntryBundle).
+			WithMirrorCheckpointFetcher(mirrorFetcher.ReadCheckpoint)
 
 		c, err := mirror.NewClient(ctx, mOpts)
 		if err != nil {
-			slog.ErrorContext(ctx, "Failed to create mirror client", slog.String("url", u), slog.Any("error", err))
-			continue
+			return nil, fmt.Errorf("failed to create mirror client for URL %q: %v", u, err)
 		}
 
 		target := &mirrorTarget{
-			url:    parsedURL,
+			url:    u,
 			client: c,
 			goals:  make(chan goal, 1),
 		}
@@ -140,66 +124,71 @@ func NewGateway(ctx context.Context, httpClient *http.Client, mirrors WitnessGro
 		go g.runWorker(ctx, target)
 	}
 
-	return g
+	return g, nil
 }
 
-// CosignCheckpoint updates the goals for all mirrors and returns a channel on which it will send
-// cosignatures as they are successfully fetched from the mirrors.
+// CosignCheckpoint updates the goals for all mirrors and returns a channel over which
+// cosignatures will be sent as they are successfully fetched from the mirrors.
 // The channel is closed once all mirrors' signatures have been sent or the context is canceled.
+//
+// It is strongly recommended that the context passed in here has a deadline or timeout set.
 func (g *Gateway) CosignCheckpoint(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+	out := make(chan []byte, len(g.targets))
+
+	// If there are no mirrors, return immediately.
 	if len(g.targets) == 0 {
-		return nil
+		// Return a _closed_ channel, not `nil`, as callers will iterate over the
+		// returned channel and we don't want to block them forever.
+		close(out)
+		return out
 	}
 
-	out := make(chan []byte, len(g.targets))
-	wg := sync.WaitGroup{}
+	N := &atomic.Uint32{}
 
-	// Send goals to each of the target workers, but don't block if they're
-	// already busy.
+	// Send updated goals to each of the target workers.
 	for _, target := range g.targets {
 		newGoal := goal{
 			cp:     cp,
 			cpSize: cpSize,
 			done: func(sig []byte, err error) {
-				defer wg.Done()
+				// Last one out please turn off the lights.
+				defer func() {
+					if N.Add(1) == uint32(len(g.targets)) {
+						close(out)
+					}
+				}()
+
 				if err != nil {
-					slog.ErrorContext(ctx, "Mirror sync failed", slog.String("url", target.url.String()), slog.Any("error", err))
+					slog.ErrorContext(ctx, "MirrorGateway: Sync failed", slog.String("url", target.url.String()), slog.Any("error", err))
 					return
 				}
-				slog.InfoContext(ctx, "Mirror sync succeeded", slog.String("url", target.url.String()), slog.Uint64("size", cpSize))
+				slog.InfoContext(ctx, "MirrorGateway: Sync succeeded", slog.String("url", target.url.String()), slog.Uint64("size", cpSize))
 				out <- sig
 			},
 		}
 
 		for done := false; !done; {
-			// Add the goal to the target worker. If there's already a goal in the channel, then we'll try to replace it since the current cosign request
-			// supercedes it. This is racy, but that's fine since we're only trying to replace a pending request - it's fine if the worker has already picked up
-			// the old goal.
+			// Send the goal to the target worker.
 			select {
 			case <-ctx.Done():
 				done = true
 			case target.goals <- newGoal:
-				// The goal was sent, we're done
-				wg.Add(1)
 				done = true
 			default:
-				// No space in the goals channel, try to supercede the goal currently in there.
+				// No space in the goals channel, try to supercede the goal currently in there with the new one.
+				// This replacement is "racy", but the worst that can happen is that the worker has already
+				// picked up the old goal and we end up simply queuing the new goal instead of replacing the old one.
 				select {
 				case oldGoal := <-target.goals:
-					// Ok, we've removed the superceded one, let's signal that it's done:
+					// Ok, we've removed the superceded goal, so we need to signal that it's done:
 					oldGoal.done(nil, fmt.Errorf("superseded by newer goal for size %d", cpSize))
-					// Then let the loop retry the send.
+					// Then let the loop retry the send in the select at the top.
 				default:
 					// Channel became empty in the meantime, let the loop retry the send.
 				}
 			}
 		}
 	}
-
-	go func() {
-		wg.Wait()
-		close(out)
-	}()
 
 	return out
 }
@@ -210,8 +199,8 @@ func (g *Gateway) CosignCheckpoint(ctx context.Context, cp []byte, cpSize uint64
 // It will block on the goals channel until a goal is received, or the context is
 // cancelled.
 func (g *Gateway) runWorker(ctx context.Context, target *mirrorTarget) {
-	slog.InfoContext(ctx, "Starting mirror worker", slog.String("url", target.url.String()))
-	defer slog.InfoContext(ctx, "Stopping mirror worker", slog.String("url", target.url.String()))
+	slog.InfoContext(ctx, "MirrorGateway: Starting worker", slog.String("url", target.url.String()))
+	defer slog.InfoContext(ctx, "MirrorGateway: Stopping worker", slog.String("url", target.url.String()))
 
 	for {
 		select {
@@ -219,36 +208,49 @@ func (g *Gateway) runWorker(ctx context.Context, target *mirrorTarget) {
 			return
 		case job, ok := <-target.goals:
 			if !ok {
-				// Channel closed, stop.
+				// Channel closed: down tools and exit.
 				return
 			}
 
-			// Loop until the goal is met, or we timeout.
-			done := false
-			interval := time.Millisecond
-			for !done {
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(interval):
-					interval = time.Second
-				}
-				// In a func for context defer.
-				func() {
-					// TODO(al): Make this configurable? Should be plenty of time for normal operation, and we'll retry anyway if we do timeout.
-					cctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
-					defer cancel()
-
-					slog.DebugContext(cctx, "Syncing mirror", slog.String("url", target.url.String()), slog.Uint64("goal", job.cpSize))
-					sigs, err := target.client.Sync(cctx, job.cp, job.cpSize)
-					if err != nil {
-						slog.WarnContext(ctx, "Mirror sync attempt failed, retrying", slog.String("url", target.url.String()), slog.Any("error", err))
-						return
-					}
-					done = true
-					job.done(sigs, nil)
-				}()
-			}
+			// TODO(al): Consider making this timeout configurable. This should be fine for the moment though.
+			goalJob := g.chaseGoal(target, job, 1*time.Minute)
+			sigs, err := goalJob(ctx)
+			job.done(sigs, err)
 		}
+	}
+}
+
+func (g *Gateway) chaseGoal(target *mirrorTarget, job goal, timeout time.Duration) func(context.Context) ([]byte, error) {
+	return func(ctx context.Context) ([]byte, error) {
+		var rSigs []byte
+		var rErr error
+
+		interval := time.Millisecond
+		// Loop until the goal is met, or we timeout.
+		for i, done := 0, false; !done; i++ {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(interval):
+				interval = time.Second
+			}
+
+			// In a func for context defer.
+			func() {
+				cctx, cancel := context.WithTimeout(ctx, timeout)
+				defer cancel()
+
+				slog.DebugContext(cctx, "MirrorGateway: Syncing mirror", slog.String("url", target.url.String()), slog.Uint64("goal", job.cpSize))
+				rSigs, rErr = target.client.Sync(cctx, job.cp, job.cpSize)
+				if rErr != nil {
+					// TODO(al): Update the client so we can tell whether an error is permanent or transient, and abandon jobs which will never succeed.
+					// Currently, a worker for a mirror which is unavailable will keep retrying ~forever until the mirror comes back.
+					slog.WarnContext(cctx, "MirrorGateway: Sync failed, retrying", slog.String("url", target.url.String()), slog.Any("error", rErr))
+					return
+				}
+				done = true
+			}()
+		}
+		return rSigs, rErr
 	}
 }

--- a/internal/mirror/gateway/mirror_gateway.go
+++ b/internal/mirror/gateway/mirror_gateway.go
@@ -1,0 +1,254 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sync"
+	"time"
+
+	"log/slog"
+
+	"github.com/transparency-dev/tessera/client/mirror"
+	"golang.org/x/mod/sumdb/note"
+)
+
+// WitnessGroup defines the subset of tessera.WitnessGroup methods needed by the gateway.
+type WitnessGroup interface {
+	WitnessEndpoints() map[string][]note.Verifier
+}
+
+// LogReader defines the subset of tessera.LogReader methods needed by the gateway.
+type LogReader interface {
+	ReadTile(ctx context.Context, level, index uint64, p uint8) ([]byte, error)
+	ReadEntryBundle(ctx context.Context, index uint64, p uint8) ([]byte, error)
+}
+
+// goal represents a desired state for a mirror.
+// It contains a target checkpoint (and its size broken out for simplicity), and a
+// callback which must be called once the goal is attained, or an error occurred.
+type goal struct {
+	cpSize uint64
+	cp     []byte
+	done   func([]byte, error)
+}
+
+// mirrorTarget represents a tlog-mirror service which we'll attempt to update.
+type mirrorTarget struct {
+	url    *url.URL
+	client *mirror.Client
+
+	goals chan goal
+}
+
+// Gateway manages the process of keeping mirrors up-to-date.
+type Gateway struct {
+	httpClient *http.Client
+	lr         LogReader
+	targets    []*mirrorTarget
+}
+
+// NewGateway creates a new Gateway that will keep mirrors up-to-date.
+func NewGateway(ctx context.Context, httpClient *http.Client, mirrors WitnessGroup, lr LogReader, logOrigin string) *Gateway {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	g := &Gateway{
+		httpClient: httpClient,
+		lr:         lr,
+	}
+
+	endpoints := mirrors.WitnessEndpoints()
+	for u := range endpoints {
+		parsedURL, err := url.Parse(u)
+		if err != nil {
+			slog.ErrorContext(ctx, "Invalid mirror URL", slog.String("url", u), slog.Any("error", err))
+			continue
+		}
+
+		tileFetcher := func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+			return lr.ReadTile(ctx, level, index, p)
+		}
+		bundleFetcher := func(ctx context.Context, index uint64, p uint8) ([]byte, error) {
+			return lr.ReadEntryBundle(ctx, index, p)
+		}
+		mirrorCheckpointFetcher := func(ctx context.Context) ([]byte, error) {
+			checkpointURL, err := parsedURL.Parse("checkpoint")
+			if err != nil {
+				return nil, err
+			}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, checkpointURL.String(), nil)
+			if err != nil {
+				return nil, err
+			}
+			resp, err := httpClient.Do(req)
+			if err != nil {
+				return nil, err
+			}
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+			if resp.StatusCode == http.StatusNotFound {
+				return nil, os.ErrNotExist
+			}
+			if resp.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("failed to fetch checkpoint from mirror: status %d", resp.StatusCode)
+			}
+			return io.ReadAll(resp.Body)
+		}
+
+		mOpts := mirror.NewOptions().
+			WithMirrorURL(parsedURL).
+			WithHTTPClient(httpClient).
+			WithLogOrigin(logOrigin).
+			WithTileFetcher(tileFetcher).
+			WithBundleFetcher(bundleFetcher).
+			WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
+
+		c, err := mirror.NewClient(ctx, mOpts)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to create mirror client", slog.String("url", u), slog.Any("error", err))
+			continue
+		}
+
+		target := &mirrorTarget{
+			url:    parsedURL,
+			client: c,
+			goals:  make(chan goal, 1),
+		}
+		g.targets = append(g.targets, target)
+
+		// Start the worker goroutine.
+		go g.runWorker(ctx, target)
+	}
+
+	return g
+}
+
+// CosignCheckpoint updates the goals for all mirrors and returns a channel on which it will send
+// cosignatures as they are successfully fetched from the mirrors.
+// The channel is closed once all mirrors' signatures have been sent or the context is canceled.
+func (g *Gateway) CosignCheckpoint(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+	if len(g.targets) == 0 {
+		return nil
+	}
+
+	out := make(chan []byte, len(g.targets))
+	wg := sync.WaitGroup{}
+
+	// Send goals to each of the target workers, but don't block if they're
+	// already busy.
+	for _, target := range g.targets {
+		newGoal := goal{
+			cp:     cp,
+			cpSize: cpSize,
+			done: func(sig []byte, err error) {
+				defer wg.Done()
+				if err != nil {
+					slog.ErrorContext(ctx, "Mirror sync failed", slog.String("url", target.url.String()), slog.Any("error", err))
+					return
+				}
+				slog.InfoContext(ctx, "Mirror sync succeeded", slog.String("url", target.url.String()), slog.Uint64("size", cpSize))
+				out <- sig
+			},
+		}
+
+		for done := false; !done; {
+			// Add the goal to the target worker. If there's already a goal in the channel, then we'll try to replace it since the current cosign request
+			// supercedes it. This is racy, but that's fine since we're only trying to replace a pending request - it's fine if the worker has already picked up
+			// the old goal.
+			select {
+			case <-ctx.Done():
+				done = true
+			case target.goals <- newGoal:
+				// The goal was sent, we're done
+				wg.Add(1)
+				done = true
+			default:
+				// No space in the goals channel, try to supercede the goal currently in there.
+				select {
+				case oldGoal := <-target.goals:
+					// Ok, we've removed the superceded one, let's signal that it's done:
+					oldGoal.done(nil, fmt.Errorf("superseded by newer goal for size %d", cpSize))
+					// Then let the loop retry the send.
+				default:
+					// Channel became empty in the meantime, let the loop retry the send.
+				}
+			}
+		}
+	}
+
+	go func() {
+		wg.Wait()
+		close(out)
+	}()
+
+	return out
+}
+
+// runWorker runs the main loop of a mirror worker: it picks up goals from the goals channel
+// and attempts to satisfy them.
+//
+// It will block on the goals channel until a goal is received, or the context is
+// cancelled.
+func (g *Gateway) runWorker(ctx context.Context, target *mirrorTarget) {
+	slog.InfoContext(ctx, "Starting mirror worker", slog.String("url", target.url.String()))
+	defer slog.InfoContext(ctx, "Stopping mirror worker", slog.String("url", target.url.String()))
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job, ok := <-target.goals:
+			if !ok {
+				// Channel closed, stop.
+				return
+			}
+
+			// Loop until the goal is met, or we timeout.
+			done := false
+			interval := time.Millisecond
+			for !done {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(interval):
+					interval = time.Second
+				}
+				// In a func for context defer.
+				func() {
+					// TODO(al): Make this configurable? Should be plenty of time for normal operation, and we'll retry anyway if we do timeout.
+					cctx, cancel := context.WithTimeout(ctx, 1*time.Minute)
+					defer cancel()
+
+					slog.DebugContext(cctx, "Syncing mirror", slog.String("url", target.url.String()), slog.Uint64("goal", job.cpSize))
+					sigs, err := target.client.Sync(cctx, job.cp, job.cpSize)
+					if err != nil {
+						slog.WarnContext(ctx, "Mirror sync attempt failed, retrying", slog.String("url", target.url.String()), slog.Any("error", err))
+						return
+					}
+					done = true
+					job.done(sigs, nil)
+				}()
+			}
+		}
+	}
+}

--- a/internal/mirror/gateway/mirror_gateway_test.go
+++ b/internal/mirror/gateway/mirror_gateway_test.go
@@ -1,0 +1,181 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gateway_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/transparency-dev/formats/log"
+	f_note "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/internal/mirror/gateway"
+	"github.com/transparency-dev/tessera/testonly"
+	"golang.org/x/mod/sumdb/note"
+)
+
+type fakeWitnessGroup struct {
+	endpoints map[string][]note.Verifier
+}
+
+func (f fakeWitnessGroup) WitnessEndpoints() map[string][]note.Verifier {
+	return f.endpoints
+}
+
+func TestGateway(t *testing.T) {
+	opts := tessera.NewAppendOptions().
+		WithCheckpointInterval(100 * time.Millisecond).
+		WithCheckpointRepublishInterval(100 * time.Millisecond)
+
+	testLog, shutdown := testonly.NewTestLog(t, opts)
+	defer func() {
+		_ = shutdown(t.Context())
+	}()
+
+	// Create a log with some entries.
+	const size = 5
+	var f tessera.IndexFuture
+	for i := range size {
+		entry := tessera.NewEntry(fmt.Appendf(nil, "entry-%d", i))
+		f = testLog.Appender.Add(t.Context(), entry)
+	}
+	a := tessera.NewPublicationAwaiter(t.Context(), testLog.LogReader.ReadCheckpoint, 100*time.Millisecond)
+	if _, _, err := a.Await(t.Context(), f); err != nil {
+		t.Fatalf("failed to add entry: %v", err)
+	}
+	goalCP, err := testLog.LogReader.ReadCheckpoint(t.Context())
+	if err != nil {
+		t.Fatalf("failed to read checkpoint: %v", err)
+	}
+
+	const numMirrors = 3
+	var verifiers []note.Verifier
+	endpoints := make(map[string][]note.Verifier)
+
+	for i := range numMirrors {
+		signer, verifier := mustNewKeypair(t, fmt.Sprintf("Mirror-%d", i))
+		server := startMockMirror(t, signer, testLog.SigVerifier)
+		defer server.Close()
+
+		endpoints[server.URL] = []note.Verifier{verifier}
+		verifiers = append(verifiers, verifier)
+	}
+
+	policy := fakeWitnessGroup{
+		endpoints: endpoints,
+	}
+
+	g := gateway.NewGateway(t.Context(), http.DefaultClient, policy, testLog.LogReader, "test")
+
+	// Call CosignCheckpoint and gather signatures.
+	sigCh := g.CosignCheckpoint(t.Context(), goalCP, size)
+	var cosigs []byte
+	for sig := range sigCh {
+		cosigs = append(cosigs, sig...)
+	}
+
+	// Verify cosignatures.
+	fullCP := append(slices.Clone(goalCP), cosigs...)
+	cp, _, n, err := log.ParseCheckpoint(fullCP, testLog.SigVerifier.Name(), testLog.SigVerifier, verifiers...)
+	if err != nil {
+		t.Fatalf("failed to verify cosigned checkpoint: %v", err)
+	}
+	if got, want := len(n.Sigs), 1+numMirrors; got != want {
+		t.Errorf("note signatures: got %d, want %d", got, want)
+	}
+	if got, want := uint64(cp.Size), uint64(size); got != want {
+		t.Errorf("checkpoint size: got %d, want %d", got, want)
+	}
+}
+
+func mustNewKeypair(t *testing.T, name string) (f_note.Signer, note.Verifier) {
+	t.Helper()
+	skey, vkey, err := note.GenerateKey(rand.Reader, name)
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+	s, err := f_note.NewSignerForCosignatureV1(skey)
+	if err != nil {
+		t.Fatalf("Failed to create signer: %v", err)
+	}
+	v, err := f_note.NewVerifierForCosignatureV1(vkey)
+	if err != nil {
+		t.Fatalf("Failed to create verifier: %v", err)
+	}
+	return s, v
+}
+
+func startMockMirror(t *testing.T, signer note.Signer, logVerifier note.Verifier) *httptest.Server {
+	t.Helper()
+	var mu sync.Mutex
+	var pendingCP []byte
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/add-checkpoint") {
+			body, _ := io.ReadAll(r.Body)
+			parts := bytes.SplitN(body, []byte("\n\n"), 2)
+			if len(parts) == 2 {
+				mu.Lock()
+				pendingCP = parts[1]
+				mu.Unlock()
+			}
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/add-entries") {
+			_, _ = io.Copy(io.Discard, r.Body)
+			mu.Lock()
+			cp := pendingCP
+			mu.Unlock()
+
+			if len(cp) == 0 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			n, err := note.Open(cp, note.VerifierList(logVerifier))
+			if err != nil {
+				t.Errorf("failed to open cp in mock: %v", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			signedNote, err := note.Sign(n, signer)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			idx := strings.Index(string(signedNote), "— "+signer.Name()+" ")
+			if idx < 0 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			sigLine := string(signedNote)[idx:]
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(sigLine))
+			return
+		}
+	}))
+
+	return server
+}

--- a/internal/mirror/gateway/mirror_gateway_test.go
+++ b/internal/mirror/gateway/mirror_gateway_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"slices"
 	"strings"
 	"sync"
@@ -35,14 +36,6 @@ import (
 	"golang.org/x/mod/sumdb/note"
 )
 
-type fakeWitnessGroup struct {
-	endpoints map[string][]note.Verifier
-}
-
-func (f fakeWitnessGroup) WitnessEndpoints() map[string][]note.Verifier {
-	return f.endpoints
-}
-
 func TestGateway(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
@@ -50,10 +43,12 @@ func TestGateway(t *testing.T) {
 		failCount  int
 	}{
 		{
+			name:       "no mirrors",
+			numMirrors: 0,
+		}, {
 			name:       "multiple mirrors",
 			numMirrors: 3,
-		},
-		{
+		}, {
 			name:       "retry on transient error",
 			numMirrors: 1,
 			failCount:  2,
@@ -86,22 +81,31 @@ func TestGateway(t *testing.T) {
 			}
 
 			var verifiers []note.Verifier
-			endpoints := make(map[string][]note.Verifier)
+			var mirrorURLs []*url.URL
 
 			for i := range tc.numMirrors {
 				signer, verifier := mustNewKeypair(t, fmt.Sprintf("Mirror-%d", i))
 				server := startMockMirror(t, signer, testLog.SigVerifier, tc.failCount)
 				defer server.Close()
 
-				endpoints[server.URL] = []note.Verifier{verifier}
+				sURL, err := url.Parse(server.URL)
+				if err != nil {
+					t.Fatalf("failed to parse mirror URL: %v", err)
+				}
+				mirrorURLs = append(mirrorURLs, sURL)
+
 				verifiers = append(verifiers, verifier)
 			}
 
-			policy := fakeWitnessGroup{
-				endpoints: endpoints,
+			g, err := gateway.NewGateway(t.Context(), gateway.Options{
+				HTTPClient: http.DefaultClient,
+				Mirrors:    mirrorURLs,
+				LogReader:  testLog.LogReader,
+				LogOrigin:  "test",
+			})
+			if err != nil {
+				t.Fatalf("failed to create gateway: %v", err)
 			}
-
-			g := gateway.NewGateway(t.Context(), http.DefaultClient, policy, testLog.LogReader, "test")
 
 			// Call CosignCheckpoint and gather signatures.
 			sigCh := g.CosignCheckpoint(t.Context(), goalCP, size)

--- a/internal/mirror/gateway/mirror_gateway_test.go
+++ b/internal/mirror/gateway/mirror_gateway_test.go
@@ -44,68 +44,85 @@ func (f fakeWitnessGroup) WitnessEndpoints() map[string][]note.Verifier {
 }
 
 func TestGateway(t *testing.T) {
-	opts := tessera.NewAppendOptions().
-		WithCheckpointInterval(100 * time.Millisecond).
-		WithCheckpointRepublishInterval(100 * time.Millisecond)
+	for _, tc := range []struct {
+		name       string
+		numMirrors int
+		failCount  int
+	}{
+		{
+			name:       "multiple mirrors",
+			numMirrors: 3,
+		},
+		{
+			name:       "retry on transient error",
+			numMirrors: 1,
+			failCount:  2,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := tessera.NewAppendOptions().
+				WithCheckpointInterval(100 * time.Millisecond).
+				WithCheckpointRepublishInterval(100 * time.Millisecond)
 
-	testLog, shutdown := testonly.NewTestLog(t, opts)
-	defer func() {
-		_ = shutdown(t.Context())
-	}()
+			testLog, shutdown := testonly.NewTestLog(t, opts)
+			defer func() {
+				_ = shutdown(t.Context())
+			}()
 
-	// Create a log with some entries.
-	const size = 5
-	var f tessera.IndexFuture
-	for i := range size {
-		entry := tessera.NewEntry(fmt.Appendf(nil, "entry-%d", i))
-		f = testLog.Appender.Add(t.Context(), entry)
-	}
-	a := tessera.NewPublicationAwaiter(t.Context(), testLog.LogReader.ReadCheckpoint, 100*time.Millisecond)
-	if _, _, err := a.Await(t.Context(), f); err != nil {
-		t.Fatalf("failed to add entry: %v", err)
-	}
-	goalCP, err := testLog.LogReader.ReadCheckpoint(t.Context())
-	if err != nil {
-		t.Fatalf("failed to read checkpoint: %v", err)
-	}
+			// Create a log with some entries.
+			const size = 5
+			var f tessera.IndexFuture
+			for i := range size {
+				entry := tessera.NewEntry(fmt.Appendf(nil, "entry-%d", i))
+				f = testLog.Appender.Add(t.Context(), entry)
+			}
+			a := tessera.NewPublicationAwaiter(t.Context(), testLog.LogReader.ReadCheckpoint, 100*time.Millisecond)
+			if _, _, err := a.Await(t.Context(), f); err != nil {
+				t.Fatalf("failed to add entry: %v", err)
+			}
+			goalCP, err := testLog.LogReader.ReadCheckpoint(t.Context())
+			if err != nil {
+				t.Fatalf("failed to read checkpoint: %v", err)
+			}
 
-	const numMirrors = 3
-	var verifiers []note.Verifier
-	endpoints := make(map[string][]note.Verifier)
+			var verifiers []note.Verifier
+			endpoints := make(map[string][]note.Verifier)
 
-	for i := range numMirrors {
-		signer, verifier := mustNewKeypair(t, fmt.Sprintf("Mirror-%d", i))
-		server := startMockMirror(t, signer, testLog.SigVerifier)
-		defer server.Close()
+			for i := range tc.numMirrors {
+				signer, verifier := mustNewKeypair(t, fmt.Sprintf("Mirror-%d", i))
+				server := startMockMirror(t, signer, testLog.SigVerifier, tc.failCount)
+				defer server.Close()
 
-		endpoints[server.URL] = []note.Verifier{verifier}
-		verifiers = append(verifiers, verifier)
-	}
+				endpoints[server.URL] = []note.Verifier{verifier}
+				verifiers = append(verifiers, verifier)
+			}
 
-	policy := fakeWitnessGroup{
-		endpoints: endpoints,
-	}
+			policy := fakeWitnessGroup{
+				endpoints: endpoints,
+			}
 
-	g := gateway.NewGateway(t.Context(), http.DefaultClient, policy, testLog.LogReader, "test")
+			g := gateway.NewGateway(t.Context(), http.DefaultClient, policy, testLog.LogReader, "test")
 
-	// Call CosignCheckpoint and gather signatures.
-	sigCh := g.CosignCheckpoint(t.Context(), goalCP, size)
-	var cosigs []byte
-	for sig := range sigCh {
-		cosigs = append(cosigs, sig...)
-	}
+			// Call CosignCheckpoint and gather signatures.
+			sigCh := g.CosignCheckpoint(t.Context(), goalCP, size)
+			var cosigs []byte
+			for sig := range sigCh {
+				cosigs = append(cosigs, sig...)
+			}
 
-	// Verify cosignatures.
-	fullCP := append(slices.Clone(goalCP), cosigs...)
-	cp, _, n, err := log.ParseCheckpoint(fullCP, testLog.SigVerifier.Name(), testLog.SigVerifier, verifiers...)
-	if err != nil {
-		t.Fatalf("failed to verify cosigned checkpoint: %v", err)
-	}
-	if got, want := len(n.Sigs), 1+numMirrors; got != want {
-		t.Errorf("note signatures: got %d, want %d", got, want)
-	}
-	if got, want := uint64(cp.Size), uint64(size); got != want {
-		t.Errorf("checkpoint size: got %d, want %d", got, want)
+			// Verify cosignatures.
+			fullCP := append(slices.Clone(goalCP), cosigs...)
+			cp, _, n, err := log.ParseCheckpoint(fullCP, testLog.SigVerifier.Name(), testLog.SigVerifier, verifiers...)
+			if err != nil {
+				t.Fatalf("failed to verify cosigned checkpoint: %v", err)
+			}
+			if got, want := len(n.Sigs), 1+tc.numMirrors; got != want {
+				t.Errorf("note signatures: got %d, want %d", got, want)
+			}
+			if got, want := uint64(cp.Size), uint64(size); got != want {
+				t.Errorf("checkpoint size: got %d, want %d", got, want)
+			}
+		})
 	}
 }
 
@@ -126,28 +143,37 @@ func mustNewKeypair(t *testing.T, name string) (f_note.Signer, note.Verifier) {
 	return s, v
 }
 
-func startMockMirror(t *testing.T, signer note.Signer, logVerifier note.Verifier) *httptest.Server {
+func startMockMirror(t *testing.T, signer note.Signer, logVerifier note.Verifier, failCount int) *httptest.Server {
 	t.Helper()
 	var mu sync.Mutex
 	var pendingCP []byte
+	attempts := 0
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if strings.HasSuffix(r.URL.Path, "/add-checkpoint") || strings.HasSuffix(r.URL.Path, "/add-entries") {
+			if attempts < failCount {
+				attempts++
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("mock error"))
+				return
+			}
+		}
+
 		if strings.HasSuffix(r.URL.Path, "/add-checkpoint") {
 			body, _ := io.ReadAll(r.Body)
 			parts := bytes.SplitN(body, []byte("\n\n"), 2)
 			if len(parts) == 2 {
-				mu.Lock()
 				pendingCP = parts[1]
-				mu.Unlock()
 			}
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 		if strings.HasSuffix(r.URL.Path, "/add-entries") {
 			_, _ = io.Copy(io.Discard, r.Body)
-			mu.Lock()
 			cp := pendingCP
-			mu.Unlock()
 
 			if len(cp) == 0 {
 				w.WriteHeader(http.StatusBadRequest)

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -239,7 +239,7 @@ func (s *Storage) newAppender(ctx context.Context, o objStore, seq sequencer, op
 	r := &Appender{
 		logStore:        logStore,
 		sequencer:       seq,
-		newCP:           opts.CheckpointPublisher(logStore, s.cfg.HTTPClient),
+		newCP:           opts.CheckpointPublisher(ctx, logStore, s.cfg.HTTPClient),
 		treeUpdated:     make(chan struct{}),
 		entriesAssigned: make(chan struct{}, 1),
 	}

--- a/storage/aws/aws.go
+++ b/storage/aws/aws.go
@@ -236,10 +236,15 @@ func (s *Storage) newAppender(ctx context.Context, o objStore, seq sequencer, op
 		},
 	}
 
+	newCP, err := opts.CheckpointPublisherContext(ctx, logStore, s.cfg.HTTPClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create checkpoint publisher: %v", err)
+	}
+
 	r := &Appender{
 		logStore:        logStore,
 		sequencer:       seq,
-		newCP:           opts.CheckpointPublisher(ctx, logStore, s.cfg.HTTPClient),
+		newCP:           newCP,
 		treeUpdated:     make(chan struct{}),
 		entriesAssigned: make(chan struct{}, 1),
 	}

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -311,7 +311,7 @@ func (s *Storage) newAppender(ctx context.Context, o objStore, seq *spannerCoord
 		},
 		nextIndex: a.sequencer.nextIndex,
 	}
-	a.newCP = opts.CheckpointPublisher(reader, s.cfg.HTTPClient)
+	a.newCP = opts.CheckpointPublisher(ctx, reader, s.cfg.HTTPClient)
 
 	if err := a.init(ctx); err != nil {
 		return nil, nil, fmt.Errorf("failed to initialise log storage: %v", err)

--- a/storage/gcp/gcp.go
+++ b/storage/gcp/gcp.go
@@ -311,7 +311,11 @@ func (s *Storage) newAppender(ctx context.Context, o objStore, seq *spannerCoord
 		},
 		nextIndex: a.sequencer.nextIndex,
 	}
-	a.newCP = opts.CheckpointPublisher(ctx, reader, s.cfg.HTTPClient)
+	var err error
+	a.newCP, err = opts.CheckpointPublisherContext(ctx, reader, s.cfg.HTTPClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create checkpoint publisher: %v", err)
+	}
 
 	if err := a.init(ctx); err != nil {
 		return nil, nil, fmt.Errorf("failed to initialise log storage: %v", err)

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -151,7 +151,7 @@ func (s *Storage) newAppender(ctx context.Context, o *logResourceStorage, opts *
 		s:          s,
 		logStorage: o,
 		cpUpdated:  make(chan struct{}),
-		newCP:      opts.CheckpointPublisher(o, s.cfg.HTTPClient),
+		newCP:      opts.CheckpointPublisher(ctx, o, s.cfg.HTTPClient),
 	}
 	if err := a.initialise(ctx); err != nil {
 		return nil, nil, err

--- a/storage/posix/files.go
+++ b/storage/posix/files.go
@@ -147,11 +147,16 @@ func (s *Storage) newAppender(ctx context.Context, o *logResourceStorage, opts *
 		return nil, nil, fmt.Errorf("requested CheckpointInterval (%v) is less than minimum permitted %v", opts.CheckpointInterval(), minCheckpointInterval)
 	}
 
+	newCP, err := opts.CheckpointPublisherContext(ctx, o, s.cfg.HTTPClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create checkpoint publisher: %v", err)
+	}
+
 	a := &appender{
 		s:          s,
 		logStorage: o,
 		cpUpdated:  make(chan struct{}),
-		newCP:      opts.CheckpointPublisher(ctx, o, s.cfg.HTTPClient),
+		newCP:      newCP,
 	}
 	if err := a.initialise(ctx); err != nil {
 		return nil, nil, err


### PR DESCRIPTION
This PR adds a simple MVP implementation of mirroring support in the append lifecycle.

This approach is almost certainly going to change, but this will let us make progress in the meantime.

Towards #945 
