### PR TITLE
Bump golangci-lint version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,5 +23,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.10.1
+          version: v2.12.2
           args: --timeout=8m


### PR DESCRIPTION
Bumps golangci-lint to v2.12.2 to try to work-around it blocking #1091 due to not being able to tell that `os.Exit` will not return :/