### PR TITLE
Add sign-subtree support to mirror

### DIFF
--- a/cmd/mtc/mirror/internal/handler/handler.go
+++ b/cmd/mtc/mirror/internal/handler/handler.go
@@ -42,6 +42,7 @@ func New(m *MirrorMux, w *witness.Witness) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /add-checkpoint", witness.NewHTTPHandler(w).AddCheckpoint)
 	mux.HandleFunc("POST /add-entries", addEntries(m))
+	mux.HandleFunc("POST /sign-subtree", witness.NewSignSubtreeHandler(m.SignSubtree))
 	return mux
 }
 

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -162,7 +162,8 @@ func TestAddEntries(t *testing.T) {
 }
 
 type mockTarget struct {
-	addEntriesFunc func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error)
+	addEntriesFunc  func(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error)
+	signSubtreeFunc func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error)
 }
 
 func (m *mockTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error) {
@@ -170,6 +171,13 @@ func (m *mockTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint
 		return m.addEntriesFunc(ctx, uploadStart, uploadEnd, ticket, next)
 	}
 	return uploadEnd, 0, nil, nil, nil
+}
+
+func (m *mockTarget) SignSubtree(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+	if m.signSubtreeFunc != nil {
+		return m.signSubtreeFunc(ctx, start, end, subRoot, proof, cp)
+	}
+	return nil, nil
 }
 
 func TestAddEntries_StatusCodes(t *testing.T) {

--- a/cmd/mtc/mirror/internal/handler/handler_test.go
+++ b/cmd/mtc/mirror/internal/handler/handler_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/witness/witness"
 )
 
 func TestAddEntries(t *testing.T) {
@@ -300,6 +301,296 @@ func TestAddEntries_StatusCodes(t *testing.T) {
 				if got := w.Body.String(); got != test.wantBody {
 					t.Errorf("want body %q, got %q", test.wantBody, got)
 				}
+			}
+		})
+	}
+}
+
+func TestSignSubtree_StatusCodes(t *testing.T) {
+	const (
+		testOrigin = "example-log"
+		testStart  = uint64(0)
+		testEnd    = uint64(4)
+		testCosig  = "— test-mirror-cosig\n"
+	)
+	testSubRoot := []byte("subroot-bytes-32-bytes-long!!!")
+	testProof := [][]byte{[]byte("proof-hash-1"), []byte("proof-hash-2")}
+	testCP := fmt.Appendf(nil, "%s\n8\n%s\n", testOrigin, base64.StdEncoding.EncodeToString([]byte("roothash-bytes-32-bytes-long!!")))
+
+	formatReqBody := func(start, end uint64, subRoot []byte, proof [][]byte, cp []byte) []byte {
+		var b bytes.Buffer
+		fmt.Fprintf(&b, "subtree %d %d\n", start, end)
+		fmt.Fprintf(&b, "%s\n", base64.StdEncoding.EncodeToString(subRoot))
+		for _, p := range proof {
+			fmt.Fprintf(&b, "%s\n", base64.StdEncoding.EncodeToString(p))
+		}
+		fmt.Fprintf(&b, "\n")
+		b.Write(cp)
+		return b.Bytes()
+	}
+
+	for _, test := range []struct {
+		name       string
+		body       func() io.Reader
+		mockTarget *mockTarget
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name: "200 ok",
+			body: func() io.Reader {
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, testCP))
+			},
+			mockTarget: &mockTarget{
+				signSubtreeFunc: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+					if start != testStart || end != testEnd {
+						return nil, fmt.Errorf("got start=%d end=%d, want %d %d", start, end, testStart, testEnd)
+					}
+					if !bytes.Equal(subRoot, testSubRoot) {
+						return nil, fmt.Errorf("got subRoot %x, want %x", subRoot, testSubRoot)
+					}
+					if len(proof) != len(testProof) {
+						return nil, fmt.Errorf("got %d proof hashes, want %d", len(proof), len(testProof))
+					}
+					for i, p := range proof {
+						if !bytes.Equal(p, testProof[i]) {
+							return nil, fmt.Errorf("proof[%d] = %x, want %x", i, p, testProof[i])
+						}
+					}
+					if !bytes.Equal(cp, testCP) {
+						return nil, fmt.Errorf("got cp %q, want %q", cp, testCP)
+					}
+					return []byte(testCosig), nil
+				},
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   testCosig,
+		},
+		{
+			name: "400 malformed request body - invalid range line",
+			body: func() io.Reader {
+				return strings.NewReader("not-a-valid-subtree-range-header\n")
+			},
+			mockTarget: &mockTarget{},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "400 malformed request body - invalid base64 subroot",
+			body: func() io.Reader {
+				return strings.NewReader(fmt.Sprintf("subtree %d %d\nnot-valid-base64!\n\n%s", testStart, testEnd, testCP))
+			},
+			mockTarget: &mockTarget{},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "400 malformed request body - invalid base64 proof",
+			body: func() io.Reader {
+				return strings.NewReader(fmt.Sprintf("subtree %d %d\n%s\nnot-valid-base64!\n\n%s", testStart, testEnd, base64.StdEncoding.EncodeToString(testSubRoot), testCP))
+			},
+			mockTarget: &mockTarget{},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "400 invalid subtree range from target",
+			body: func() io.Reader {
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, testCP))
+			},
+			mockTarget: &mockTarget{
+				signSubtreeFunc: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+					return nil, witness.ErrSubtreeRangeInvalid
+				},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "403 no witness signature",
+			body: func() io.Reader {
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, testCP))
+			},
+			mockTarget: &mockTarget{
+				signSubtreeFunc: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+					return nil, witness.ErrNoWitnessSignature
+				},
+			},
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name: "404 unknown log (from mux)",
+			body: func() io.Reader {
+				unknownCP := []byte("unknown-log-origin\n8\n47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n")
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, unknownCP))
+			},
+			mockTarget: &mockTarget{},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "404 unknown log (from target)",
+			body: func() io.Reader {
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, testCP))
+			},
+			mockTarget: &mockTarget{
+				signSubtreeFunc: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+					return nil, witness.ErrUnknownLog
+				},
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name: "422 invalid proof",
+			body: func() io.Reader {
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, testCP))
+			},
+			mockTarget: &mockTarget{
+				signSubtreeFunc: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+					return nil, witness.ErrInvalidProof
+				},
+			},
+			wantStatus: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "429 pushback",
+			body: func() io.Reader {
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, testCP))
+			},
+			mockTarget: &mockTarget{
+				signSubtreeFunc: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+					return nil, witness.ErrPushback
+				},
+			},
+			wantStatus: http.StatusTooManyRequests,
+		},
+		{
+			name: "501 not implemented",
+			body: func() io.Reader {
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, testCP))
+			},
+			mockTarget: &mockTarget{
+				signSubtreeFunc: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+					return nil, witness.ErrNotImplemented
+				},
+			},
+			wantStatus: http.StatusNotImplemented,
+		},
+		{
+			name: "500 internal server error",
+			body: func() io.Reader {
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, testCP))
+			},
+			mockTarget: &mockTarget{
+				signSubtreeFunc: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+					return nil, errors.New("something went wrong")
+				},
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "500 malformed checkpoint in request",
+			body: func() io.Reader {
+				badCP := []byte("not a checkpoint")
+				return bytes.NewReader(formatReqBody(testStart, testEnd, testSubRoot, testProof, badCP))
+			},
+			mockTarget: &mockTarget{},
+			wantStatus: http.StatusInternalServerError,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mux := NewMirrorMux()
+			_ = mux.AddTarget(testOrigin, test.mockTarget)
+			h := New(mux, nil)
+
+			req := httptest.NewRequest(http.MethodPost, "/sign-subtree", test.body())
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, req)
+
+			if w.Code != test.wantStatus {
+				t.Errorf("want status %d, got %d: %s", test.wantStatus, w.Code, w.Body.String())
+			}
+			if test.wantBody != "" {
+				if got := w.Body.String(); got != test.wantBody {
+					t.Errorf("want body %q, got %q", test.wantBody, got)
+				}
+			}
+		})
+	}
+}
+
+func TestMirrorMux_SignSubtree(t *testing.T) {
+	const (
+		origin1 = "log-1"
+		origin2 = "log-2"
+	)
+	cp1 := fmt.Appendf(nil, "%s\n10\n47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n", origin1)
+	cp2 := fmt.Appendf(nil, "%s\n20\n47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n", origin2)
+	subRoot := []byte("subroot")
+	proof := [][]byte{[]byte("p1")}
+
+	for _, test := range []struct {
+		name        string
+		cp          []byte
+		target1Func func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error)
+		target2Func func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error)
+		wantCosig   string
+		wantErr     error
+		wantAnyErr  bool
+	}{
+		{
+			name: "dispatches to target 1",
+			cp:   cp1,
+			target1Func: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+				return []byte("cosig-1"), nil
+			},
+			target2Func: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+				t.Fatalf("target2 should not be called")
+				return nil, nil
+			},
+			wantCosig: "cosig-1",
+		},
+		{
+			name: "dispatches to target 2",
+			cp:   cp2,
+			target1Func: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+				t.Fatalf("target1 should not be called")
+				return nil, nil
+			},
+			target2Func: func(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+				return []byte("cosig-2"), nil
+			},
+			wantCosig: "cosig-2",
+		},
+		{
+			name:    "unknown origin returns ErrUnknownLog",
+			cp:      []byte("unknown-log\n5\n47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n"),
+			wantErr: ErrUnknownLog,
+		},
+		{
+			name:       "malformed checkpoint returns error",
+			cp:         []byte("not a valid checkpoint"),
+			wantAnyErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			mux := NewMirrorMux()
+			_ = mux.AddTarget(origin1, &mockTarget{signSubtreeFunc: test.target1Func})
+			_ = mux.AddTarget(origin2, &mockTarget{signSubtreeFunc: test.target2Func})
+
+			got, err := mux.SignSubtree(t.Context(), 0, 4, subRoot, proof, test.cp)
+			if test.wantAnyErr {
+				if err == nil {
+					t.Fatalf("got nil error, want non-nil error")
+				}
+				return
+			}
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("got error %v, want %v", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(got) != test.wantCosig {
+				t.Errorf("got cosig %q, want %q", string(got), test.wantCosig)
 			}
 		})
 	}

--- a/cmd/mtc/mirror/internal/handler/mirror_mux.go
+++ b/cmd/mtc/mirror/internal/handler/mirror_mux.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/internal/parse"
 )
 
 var (
@@ -65,6 +66,21 @@ func (m *MirrorMux) AddEntries(ctx context.Context, origin string, uploadStart, 
 	return t.AddEntries(ctx, uploadStart, uploadEnd, ticket, next)
 }
 
+func (m *MirrorMux) SignSubtree(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+	cpOrigin, cpSize, _, err := parse.CheckpointUnsafe(cp)
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := m.target(cpOrigin)
+	if err != nil {
+		return nil, ErrUnknownLog
+	}
+	slog.InfoContext(ctx, "SignSubtree", slog.String("origin", cpOrigin), slog.Uint64("size", cpSize))
+
+	return t.SignSubtree(ctx, start, end, subRoot, proof, cp)
+}
+
 // target returns the target for the given origin, or ErrUnknownLog if it doesn't exist.
 func (m *MirrorMux) target(origin string) (MirrorTarget, error) {
 	m.mu.RLock()
@@ -80,4 +96,5 @@ func (m *MirrorMux) target(origin string) (MirrorTarget, error) {
 type MirrorTarget interface {
 	// AddEntries adds verified consistent entries to the mirror.
 	AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error)
+	SignSubtree(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error)
 }

--- a/cmd/mtc/mirror/internal/handler/mirror_mux.go
+++ b/cmd/mtc/mirror/internal/handler/mirror_mux.go
@@ -99,7 +99,9 @@ func (m *MirrorMux) target(origin string) (MirrorTarget, error) {
 type MirrorTarget interface {
 	// AddEntries adds verified consistent entries to the mirror.
 	AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error)
-	// SignSubtree should verify that the provided checkpoint originates from a known log and is valid, and that the provided subtree and proof
-	// are valid for the provided checkpoint, and, if so, returns a cosignature for the subtree.
+	// SignSubtree should verify that:
+	// - The provided checkpoint originates from a known log, is valid, and is counter-signed by the same key which will cosign the subtree.
+	// - The provided subtree and proof are valid for the provided checkpoint.
+	// If all checks pass, it should return a cosignature for the subtree, or an error.
 	SignSubtree(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error)
 }

--- a/cmd/mtc/mirror/internal/handler/mirror_mux.go
+++ b/cmd/mtc/mirror/internal/handler/mirror_mux.go
@@ -16,18 +16,18 @@ package handler
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/internal/parse"
+	"github.com/transparency-dev/witness/witness"
 )
 
 var (
 	// ErrUnknownLog is returned when a requested log is unknown to the mirror
-	ErrUnknownLog = errors.New("unknown log origin")
+	ErrUnknownLog = witness.ErrUnknownLog
 )
 
 // NewMirrorMux creates a new MirrorMux from the provided map of origins to mirror targets.
@@ -67,7 +67,10 @@ func (m *MirrorMux) AddEntries(ctx context.Context, origin string, uploadStart, 
 }
 
 func (m *MirrorMux) SignSubtree(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
-	cpOrigin, cpSize, _, err := parse.CheckpointUnsafe(cp)
+	// Need to crack open the checkpoint to figure out the origin so we know which mux target to send it to.
+	// This is safe, though, because the target's SignSubtree will open the checkpoint properly, verifying its
+	// signature and asserting the origin is correct.
+	cpOrigin, _, _, err := parse.CheckpointUnsafe(cp)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +79,8 @@ func (m *MirrorMux) SignSubtree(ctx context.Context, start, end uint64, subRoot 
 	if err != nil {
 		return nil, ErrUnknownLog
 	}
-	slog.InfoContext(ctx, "SignSubtree", slog.String("origin", cpOrigin), slog.Uint64("size", cpSize))
 
+	slog.InfoContext(ctx, "SignSubtree", slog.String("origin", cpOrigin))
 	return t.SignSubtree(ctx, start, end, subRoot, proof, cp)
 }
 
@@ -96,5 +99,7 @@ func (m *MirrorMux) target(origin string) (MirrorTarget, error) {
 type MirrorTarget interface {
 	// AddEntries adds verified consistent entries to the mirror.
 	AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, next func() (*tessera.MirrorPackage, error)) (nextIdx uint64, curSize uint64, newTicket []byte, cosigs []byte, err error)
+	// SignSubtree should verify that the provided checkpoint originates from a known log and is valid, and that the provided subtree and proof
+	// are valid for the provided checkpoint, and, if so, returns a cosignature for the subtree.
 	SignSubtree(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error)
 }

--- a/cmd/mtc/mirror/posix/main.go
+++ b/cmd/mtc/mirror/posix/main.go
@@ -126,7 +126,7 @@ func main() {
 //
 // The target directory for the driver is derived from the storage directory and the origin in accordance
 // with the `tlog-mirror` spec, allowing the root of the storage directory to be exported directly to read-only clients.
-func newMirrorTarget(ctx context.Context, w *witness.Witness, origin string, logVerifier note.Verifier, mirrorSigner note.Signer) (*tessera.MirrorTarget, error) {
+func newMirrorTarget(ctx context.Context, w *witness.Witness, origin string, logVerifier note.Verifier, mirrorSigner fnote.SubtreeSigner) (*tessera.MirrorTarget, error) {
 	if origin == "" {
 		return nil, fmt.Errorf("origin cannot be empty")
 	}
@@ -230,7 +230,7 @@ func witnessCosignerFromFlags(ctx context.Context) []note.Signer {
 	return []note.Signer{mustCreateCosigner(ctx, *witnessCosignerPath)}
 }
 
-func mustCreateCosigner(ctx context.Context, path string) note.Signer {
+func mustCreateCosigner(ctx context.Context, path string) fnote.SubtreeSigner {
 	if path == "" {
 		slog.ErrorContext(ctx, "Cosigner key path not specified")
 		os.Exit(1)
@@ -240,7 +240,7 @@ func mustCreateCosigner(ctx context.Context, path string) note.Signer {
 		slog.ErrorContext(ctx, "Failed to read cosigner key", slog.String("path", path), slog.Any("error", err))
 		os.Exit(1)
 	}
-	s, err := fnote.NewSignerForCosignatureV1(string(r))
+	s, err := fnote.NewMLDSASigner(string(r))
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create cosigner", slog.String("path", path), slog.Any("error", err))
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/rivo/tview v0.42.0
 	github.com/transparency-dev/formats v0.1.2-0.20260805102052-38e6e69c4152
 	github.com/transparency-dev/merkle v0.0.3-0.20260727102338-4491f478b7dc
-	github.com/transparency-dev/witness v0.0.0-20260810125022-f643e5982b05
+	github.com/transparency-dev/witness v0.0.0-20260811161034-ce89de7de1be
 	go.opentelemetry.io/contrib/detectors/aws/ec2/v2 v2.5.2
 	go.opentelemetry.io/contrib/detectors/aws/ecs v1.45.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/transparency-dev/formats v0.1.2-0.20260805102052-38e6e69c4152 h1:jFaz
 github.com/transparency-dev/formats v0.1.2-0.20260805102052-38e6e69c4152/go.mod h1:P0kg1ftMVew4S2XrFP+u+CZsF50yFGSstDFBKgA6XYk=
 github.com/transparency-dev/merkle v0.0.3-0.20260727102338-4491f478b7dc h1:DaUOzC/KJOVtUqxKoFiEAQhoRu+TV8GaMKXQg94zRqs=
 github.com/transparency-dev/merkle v0.0.3-0.20260727102338-4491f478b7dc/go.mod h1:E+iHk6bS+tIgIJGD4TMeAjSjhQ9wPfL/ST4pXyITjdU=
-github.com/transparency-dev/witness v0.0.0-20260810125022-f643e5982b05 h1:1jrB4qrTFKanNaxr8TPdDKwIFnguAgp6nwl5nzSiDtU=
-github.com/transparency-dev/witness v0.0.0-20260810125022-f643e5982b05/go.mod h1:8kubNAzXuDgpH+SPlC+yQn+3GYeEBvOknjv5fpFWEMk=
+github.com/transparency-dev/witness v0.0.0-20260811161034-ce89de7de1be h1:gIpR+JFv5Y5iaH7tGsXN2roK+nn26wdUegVjf5luVqg=
+github.com/transparency-dev/witness v0.0.0-20260811161034-ce89de7de1be/go.mod h1:8kubNAzXuDgpH+SPlC+yQn+3GYeEBvOknjv5fpFWEMk=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -34,12 +34,15 @@ import (
 	"unicode/utf8"
 
 	"github.com/transparency-dev/formats/log"
+	fnote "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/merkle"
 	"github.com/transparency-dev/merkle/compact"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/witness/persistence/inmemory"
+	"github.com/transparency-dev/witness/witness"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -61,7 +64,7 @@ const maxExcessEntries = 2048
 
 // MirrorOptions holds mirror lifecycle settings for all storage implementations.
 type MirrorOptions struct {
-	signer      note.Signer
+	signer      fnote.SubtreeSigner
 	cpSource    func(context.Context) ([]byte, error)
 	logVerifier note.Verifier
 	origin      string
@@ -86,7 +89,7 @@ func (o *MirrorOptions) WithLogVerifier(v note.Verifier) *MirrorOptions {
 }
 
 // WithSigner configures the note.Signer to use when cosigning checkpoints.
-func (o *MirrorOptions) WithSigner(s note.Signer) *MirrorOptions {
+func (o *MirrorOptions) WithSigner(s fnote.SubtreeSigner) *MirrorOptions {
 	o.signer = s
 	return o
 }
@@ -97,7 +100,7 @@ func (o *MirrorOptions) WithCheckpointSource(f func(context.Context) ([]byte, er
 }
 
 // Signer returns the configured note.Signer.
-func (o *MirrorOptions) Signer() note.Signer {
+func (o *MirrorOptions) Signer() fnote.SubtreeSigner {
 	return o.signer
 }
 
@@ -148,9 +151,10 @@ type MirrorTarget struct {
 	reader             LogReader
 	cpSource           func(context.Context) ([]byte, error)
 	origin             string
-	signer             note.Signer
+	signer             fnote.SubtreeSigner
 	logVerifier        note.Verifier
 	verifySubtreeProof func(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte, root []byte) error
+	signSubtree        signSubtreeFunc
 	ticketKey          []byte
 }
 
@@ -180,6 +184,10 @@ func NewMirrorTarget(ctx context.Context, d Driver, opts *MirrorOptions) (*Mirro
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive ticket key: %v", err)
 	}
+	signSubtree, err := subtreeWitness(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create subtree witness: %v", err)
+	}
 	return &MirrorTarget{
 		writer:             mw,
 		reader:             r,
@@ -188,6 +196,7 @@ func NewMirrorTarget(ctx context.Context, d Driver, opts *MirrorOptions) (*Mirro
 		logVerifier:        opts.logVerifier,
 		origin:             opts.origin,
 		verifySubtreeProof: proof.VerifySubtreeConsistency,
+		signSubtree:        signSubtree,
 		ticketKey:          tK,
 	}, nil
 }
@@ -497,6 +506,11 @@ func (mt *MirrorTarget) open(sealed []byte) ([]byte, error) {
 	return b, nil
 }
 
+// SignSubtree returns a cosignature for a subtree of the mirrored log.
+func (mt *MirrorTarget) SignSubtree(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
+	return mt.signSubtree(ctx, start, end, subRoot, proof, cp)
+}
+
 func signNote(n *note.Note, signers ...note.Signer) ([]byte, []byte, error) {
 	// Code below is a lightly tweaked snippet from sumdb/note/note.go
 	// https://cs.opensource.google/go/x/mod/+/refs/tags/v0.24.0:sumdb/note/note.go;l=625-649
@@ -554,4 +568,32 @@ func signNote(n *note.Note, signers ...note.Signer) ([]byte, []byte, error) {
 // It must be non-empty and not have any Unicode spaces or pluses.
 func isValidSignerName(name string) bool {
 	return name != "" && utf8.ValidString(name) && strings.IndexFunc(name, unicode.IsSpace) < 0 && !strings.Contains(name, "+")
+}
+
+type signSubtreeFunc func(context.Context, uint64, uint64, []byte, [][]byte, []byte) ([]byte, error)
+
+// subtreeWitness returns a function which implements the witness sign-subtree operation for the configured log.
+//
+// The returned function will only sign subtrees where the provided checkpoint has already been signed by the mirror.
+func subtreeWitness(ctx context.Context, opts *MirrorOptions) (signSubtreeFunc, error) {
+	// Instantiate a witness for the configured log, but we'll only use its SignSubtree method.
+	// SignSubtree doesn't persist any state since everything required is provided by the request.
+	subW, err := witness.New(ctx, witness.Opts{
+		// Use in-memory persistence as we don't need to persist any state for the SignSubtree operation.
+		Persistence: inmemory.New(),
+		Signers:     []note.Signer{opts.signer},
+		VerifierForLog: func(_ context.Context, origin string) (note.Verifier, bool, error) {
+			// Only accept the log we're configured to mirror.
+			if origin != opts.origin {
+				return nil, false, nil
+			}
+			return opts.logVerifier, true, nil
+		},
+		EnableSubtreeSigning: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("witness.New: %v", err)
+	}
+
+	return subW.SignSubtree, nil
 }

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -378,16 +378,16 @@ func TestMirrorTarget_AddEntries_ZeroCheckpoint(t *testing.T) {
 	}
 }
 
-func mustGenerateKey(origin string) (note.Signer, note.Verifier) {
+func mustGenerateKey(origin string) (fnote.SubtreeSigner, fnote.SubtreeVerifier) {
 	sk, vk, err := fnote.GenerateMLDSAKey(origin)
 	if err != nil {
 		panic(fmt.Errorf("Failed to generate key for %q: %v", origin, err))
 	}
-	s, err := fnote.NewSignerForCosignatureV1(sk)
+	s, err := fnote.NewMLDSASigner(sk)
 	if err != nil {
 		panic(fmt.Errorf("Failed to instantiate signer: %v", err))
 	}
-	v, err := fnote.NewVerifierForCosignatureV1(vk)
+	v, err := fnote.NewMLDSAVerifier(vk)
 	if err != nil {
 		panic(fmt.Errorf("Failed to instantiate verifier: %v", err))
 	}

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -22,12 +22,17 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"strings"
 	"testing"
 
 	fnote "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/merkle"
+	"github.com/transparency-dev/merkle/compact"
+	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
+	"github.com/transparency-dev/witness/witness"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -67,9 +72,9 @@ const (
 )
 
 var (
-	testLogSigner, testLogVerifier = mustGenerateKey(testPendingCPOrigin)
-	testMirrorSigner, _            = mustGenerateKey(testMirrorOrigin)
-	testPendingCP                  = mustSignCP(testPendingCPOrigin, testPendingCPSize, testPendingCPRoot, testLogSigner)
+	testLogSigner, testLogVerifier       = mustGenerateKey(testPendingCPOrigin)
+	testMirrorSigner, testMirrorVerifier = mustGenerateKey(testMirrorOrigin)
+	testPendingCP                        = mustSignCP(testPendingCPOrigin, testPendingCPSize, testPendingCPRoot, testLogSigner)
 )
 
 func TestTicketRoundTrip(t *testing.T) {
@@ -794,4 +799,210 @@ type fakeDriver struct{}
 
 func (f *fakeDriver) MirrorWriter(ctx context.Context, opts *MirrorOptions) (MirrorWriter, LogReader, error) {
 	return &fakeMirrorWriter{}, &fakeLogReader{}, nil
+}
+
+func TestMirrorTarget_SignSubtree(t *testing.T) {
+	const treeSize = uint64(8)
+	ctx := t.Context()
+
+	// Build a small Merkle tree with 8 leaves.
+	rf := &compact.RangeFactory{Hash: rfc6962.DefaultHasher.HashChildren}
+	nodes := make(map[compact.NodeID][]byte)
+	cr := rf.NewEmptyRange(0)
+	for i := range treeSize {
+		leafHash := rfc6962.DefaultHasher.HashLeaf(fmt.Appendf(nil, "entry-%d", i))
+		if err := cr.Append(leafHash, func(id compact.NodeID, hash []byte) {
+			nodes[id] = hash
+		}); err != nil {
+			t.Fatalf("cr.Append: %v", err)
+		}
+	}
+	rootHash, err := cr.GetRootHash(nil)
+	if err != nil {
+		t.Fatalf("GetRootHash: %v", err)
+	}
+
+	// Build subtree [0, 4) root.
+	subCR := rf.NewEmptyRange(0)
+	for i := range uint64(4) {
+		leafHash := rfc6962.DefaultHasher.HashLeaf(fmt.Appendf(nil, "entry-%d", i))
+		if err := subCR.Append(leafHash, nil); err != nil {
+			t.Fatalf("subCR.Append: %v", err)
+		}
+	}
+	validSubRoot, err := subCR.GetRootHash(nil)
+	if err != nil {
+		t.Fatalf("subCR.GetRootHash: %v", err)
+	}
+
+	// Consistency proof for [0, 4) in tree of size 8.
+	proofNodes, err := proof.SubtreeConsistency(0, 4, treeSize)
+	if err != nil {
+		t.Fatalf("proof.SubtreeConsistency: %v", err)
+	}
+	validProof := make([][]byte, len(proofNodes.IDs))
+	for i, id := range proofNodes.IDs {
+		validProof[i] = nodes[id]
+	}
+
+	otherMirrorSigner, _ := mustGenerateKey("other-mirror-signer")
+	otherOriginSigner, _ := mustGenerateKey("other-origin")
+
+	opts := NewMirrorOptions().
+		WithLogVerifier(testLogVerifier).
+		WithSigner(testMirrorSigner).
+		WithOrigin(testPendingCPOrigin).
+		WithCheckpointSource(func(ctx context.Context) ([]byte, error) {
+			return nil, nil
+		})
+
+	mt, err := NewMirrorTarget(ctx, &fakeDriver{}, opts)
+	if err != nil {
+		t.Fatalf("NewMirrorTarget failed: %v", err)
+	}
+
+	for _, test := range []struct {
+		name      string
+		start     uint64
+		end       uint64
+		subRoot   []byte
+		proof     [][]byte
+		cp        []byte
+		wantErr   error
+		wantCosig bool
+	}{
+		{
+			name:      "success",
+			start:     0,
+			end:       4,
+			subRoot:   validSubRoot,
+			proof:     validProof,
+			cp:        mustCosignCP(t, testPendingCPOrigin, treeSize, rootHash, testLogSigner, testMirrorSigner),
+			wantCosig: true,
+		},
+		{
+			name:    "checkpoint missing mirror cosignature",
+			start:   0,
+			end:     4,
+			subRoot: validSubRoot,
+			proof:   validProof,
+			cp:      mustCosignCP(t, testPendingCPOrigin, treeSize, rootHash, testLogSigner),
+			wantErr: witness.ErrNoWitnessSignature,
+		},
+		{
+			name:    "checkpoint signed by wrong mirror key",
+			start:   0,
+			end:     4,
+			subRoot: validSubRoot,
+			proof:   validProof,
+			cp:      mustCosignCP(t, testPendingCPOrigin, treeSize, rootHash, testLogSigner, otherMirrorSigner),
+			wantErr: witness.ErrNoWitnessSignature,
+		},
+		{
+			name:    "origin mismatch",
+			start:   0,
+			end:     4,
+			subRoot: validSubRoot,
+			proof:   validProof,
+			cp:      mustCosignCP(t, "other-origin", treeSize, rootHash, otherOriginSigner, testMirrorSigner),
+			wantErr: witness.ErrUnknownLog,
+		},
+		{
+			name:    "invalid subtree range - end > cp.Size",
+			start:   0,
+			end:     16,
+			subRoot: validSubRoot,
+			proof:   validProof,
+			cp:      mustCosignCP(t, testPendingCPOrigin, treeSize, rootHash, testLogSigner, testMirrorSigner),
+			wantErr: witness.ErrSubtreeRangeInvalid,
+		},
+		{
+			name:    "invalid subtree range - unaligned",
+			start:   1,
+			end:     3,
+			subRoot: validSubRoot,
+			proof:   validProof,
+			cp:      mustCosignCP(t, testPendingCPOrigin, treeSize, rootHash, testLogSigner, testMirrorSigner),
+			wantErr: witness.ErrSubtreeRangeInvalid,
+		},
+		{
+			name:    "invalid proof - corrupted hash",
+			start:   0,
+			end:     4,
+			subRoot: validSubRoot,
+			proof:   [][]byte{[]byte("corrupted-proof-hash-of-32-bytes")},
+			cp:      mustCosignCP(t, testPendingCPOrigin, treeSize, rootHash, testLogSigner, testMirrorSigner),
+			wantErr: witness.ErrInvalidProof,
+		},
+		{
+			name:    "invalid proof - wrong subtree root",
+			start:   0,
+			end:     4,
+			subRoot: make([]byte, 32),
+			proof:   validProof,
+			cp:      mustCosignCP(t, testPendingCPOrigin, treeSize, rootHash, testLogSigner, testMirrorSigner),
+			wantErr: witness.ErrInvalidProof,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := mt.SignSubtree(ctx, test.start, test.end, test.subRoot, test.proof, test.cp)
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("got error %v, want %v", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if test.wantCosig {
+				if len(got) == 0 {
+					t.Fatalf("got empty cosig, want non-empty")
+				}
+				sigLine := strings.TrimSpace(string(got))
+				parts := strings.Split(sigLine, " ")
+				if len(parts) != 3 || parts[0] != "—" {
+					t.Fatalf("unexpected cosig format: %q", sigLine)
+				}
+				sigWithHash, err := base64.StdEncoding.DecodeString(parts[2])
+				if err != nil {
+					t.Fatalf("failed to decode sig base64: %v", err)
+				}
+				if len(sigWithHash) < 4 {
+					t.Fatalf("sig too short: %d bytes", len(sigWithHash))
+				}
+				sig := sigWithHash[4:]
+				if !testMirrorVerifier.VerifySubtree(0, testPendingCPOrigin, test.start, test.end, test.subRoot, sig) {
+					t.Errorf("VerifySubtree failed for generated cosignature")
+				}
+			} else {
+				if len(got) != 0 {
+					t.Fatalf("got non-empty cosig, want empty")
+				}
+			}
+		})
+	}
+}
+
+func TestMirrorTarget_SubtreeWitness_NilSigner(t *testing.T) {
+	opts := NewMirrorOptions().
+		WithLogVerifier(testLogVerifier).
+		WithOrigin(testPendingCPOrigin).
+		WithCheckpointSource(func(ctx context.Context) ([]byte, error) {
+			return nil, nil
+		})
+	_, err := NewMirrorTarget(t.Context(), &fakeDriver{}, opts)
+	if err == nil {
+		t.Fatalf("NewMirrorTarget with nil signer: got nil err, want error")
+	}
+}
+
+// mustCosignCP is a helper to sign checkpoints with multiple signers.
+func mustCosignCP(t *testing.T, origin string, size uint64, root []byte, signers ...note.Signer) []byte {
+	t.Helper()
+	raw, err := note.Sign(&note.Note{Text: fmt.Sprintf("%s\n%d\n%s\n", origin, size, base64.StdEncoding.EncodeToString(root))}, signers...)
+	if err != nil {
+		t.Fatalf("Failed to sign note: %v", err)
+	}
+	return raw
 }


### PR DESCRIPTION
This PR adds support for the `sign-subtree` request to the MTC mirror implementation.

Towards #945 