### PR TITLE
[MTC] Add `GetSubtreeFor` methods for upcoming `ProofToLandmark` implementation

### DIFF
--- a/cmd/mtc/log/internal/checkpoint/reader.go
+++ b/cmd/mtc/log/internal/checkpoint/reader.go
@@ -66,8 +66,8 @@ func (r *Reader) Checkpoint(ctx context.Context) ([]byte, error) {
 }
 
 // LatestSize returns the most recently observed checkpoint size.
-func (r *Reader) LatestSize(_ context.Context) (uint64, error) {
+func (r *Reader) LatestSize() uint64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.latestSize, nil
+	return r.latestSize
 }

--- a/cmd/mtc/log/internal/checkpoint/reader.go
+++ b/cmd/mtc/log/internal/checkpoint/reader.go
@@ -1,0 +1,75 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package checkpoint provides helpers for reading checkpoint and caching sizes.
+package checkpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	flog "github.com/transparency-dev/formats/log"
+)
+
+// Reader wraps a ReadCheckpoint function to cache the latest checkpoint size observed from storage.
+type Reader struct {
+	readCheckpoint func(context.Context) ([]byte, error)
+
+	mu         sync.RWMutex
+	latestSize uint64
+}
+
+// NewReader creates a new Reader instance wrapping readCheckpoint and reads the initial checkpoint from storage.
+func NewReader(ctx context.Context, readCheckpoint func(context.Context) ([]byte, error)) (*Reader, error) {
+	if readCheckpoint == nil {
+		return nil, errors.New("readCheckpoint must not be nil")
+	}
+	r := &Reader{
+		readCheckpoint: readCheckpoint,
+	}
+	if _, err := r.Checkpoint(ctx); err != nil {
+		return nil, fmt.Errorf("initial checkpoint read: %v", err)
+	}
+	return r, nil
+}
+
+// Checkpoint reads the latest checkpoint from underlying storage and updates the latest observed size.
+func (r *Reader) Checkpoint(ctx context.Context) ([]byte, error) {
+	rawCp, err := r.readCheckpoint(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var cp flog.Checkpoint
+	if _, err := cp.Unmarshal(rawCp); err != nil {
+		return nil, fmt.Errorf("parse checkpoint: %v", err)
+	}
+
+	r.mu.Lock()
+	if cp.Size > r.latestSize {
+		r.latestSize = cp.Size
+	}
+	r.mu.Unlock()
+
+	return rawCp, nil
+}
+
+// LatestSize returns the most recently observed checkpoint size.
+func (r *Reader) LatestSize(_ context.Context) (uint64, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.latestSize, nil
+}

--- a/cmd/mtc/log/internal/checkpoint/reader.go
+++ b/cmd/mtc/log/internal/checkpoint/reader.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	flog "github.com/transparency-dev/formats/log"
+	"github.com/transparency-dev/tessera/internal/parse"
 )
 
 // Reader wraps a ReadCheckpoint function to cache the latest checkpoint size observed from storage.
@@ -53,15 +53,13 @@ func (r *Reader) Checkpoint(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 
-	var cp flog.Checkpoint
-	if _, err := cp.Unmarshal(rawCp); err != nil {
+	_, size, _, err := parse.CheckpointUnsafe(rawCp)
+	if err != nil {
 		return nil, fmt.Errorf("parse checkpoint: %v", err)
 	}
 
 	r.mu.Lock()
-	if cp.Size > r.latestSize {
-		r.latestSize = cp.Size
-	}
+	r.latestSize = max(r.latestSize, size)
 	r.mu.Unlock()
 
 	return rawCp, nil

--- a/cmd/mtc/log/internal/checkpoint/reader_test.go
+++ b/cmd/mtc/log/internal/checkpoint/reader_test.go
@@ -79,10 +79,7 @@ func TestNewReader(t *testing.T) {
 			if tc.wantErr {
 				return
 			}
-			size, err := r.LatestSize(ctx)
-			if err != nil {
-				t.Fatalf("LatestSize() error = %v", err)
-			}
+			size := r.LatestSize()
 			if size != tc.wantSize {
 				t.Errorf("LatestSize() = %d, want %d", size, tc.wantSize)
 			}
@@ -147,10 +144,7 @@ func TestReader_Checkpoint(t *testing.T) {
 				t.Errorf("Checkpoint() = %q, want %q", cp, tc.wantCP)
 			}
 
-			size, err := r.LatestSize(ctx)
-			if err != nil {
-				t.Fatalf("LatestSize() error = %v", err)
-			}
+			size := r.LatestSize()
 			if size != tc.wantSize {
 				t.Errorf("LatestSize() = %d, want %d", size, tc.wantSize)
 			}
@@ -210,19 +204,13 @@ func TestReader_LatestSize(t *testing.T) {
 				}
 			}
 
-			size, err := r.LatestSize(ctx)
-			if err != nil {
-				t.Fatalf("LatestSize() unexpected error: %v", err)
-			}
+			size := r.LatestSize()
 			if size != tc.wantSize {
 				t.Errorf("LatestSize() = %d, want %d", size, tc.wantSize)
 			}
 
 			// Subsequent LatestSize call returns cached size without triggering additional storage reads
-			size, err = r.LatestSize(ctx)
-			if err != nil {
-				t.Fatalf("subsequent LatestSize() unexpected error: %v", err)
-			}
+			size = r.LatestSize()
 			if size != tc.wantSize {
 				t.Errorf("subsequent LatestSize() = %d, want %d", size, tc.wantSize)
 			}

--- a/cmd/mtc/log/internal/checkpoint/reader_test.go
+++ b/cmd/mtc/log/internal/checkpoint/reader_test.go
@@ -1,0 +1,234 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func mockCheckpoint(origin string, size uint64) []byte {
+	return []byte(fmt.Sprintf("%s\n%d\nAAAA\n", origin, size))
+}
+
+func TestNewReader(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		readCP   func(context.Context) ([]byte, error)
+		wantSize uint64
+		wantErr  bool
+	}{
+		{
+			name: "successful initial read",
+			readCP: func(_ context.Context) ([]byte, error) {
+				return mockCheckpoint("test.log", 100), nil
+			},
+			wantSize: 100,
+		},
+		{
+			name: "successful initial read with size 0",
+			readCP: func(_ context.Context) ([]byte, error) {
+				return mockCheckpoint("test.log", 0), nil
+			},
+			wantSize: 0,
+		},
+		{
+			name:    "nil readCheckpoint function",
+			readCP:  nil,
+			wantErr: true,
+		},
+		{
+			name: "storage error on initial read",
+			readCP: func(_ context.Context) ([]byte, error) {
+				return nil, errors.New("network error")
+			},
+			wantErr: true,
+		},
+		{
+			name: "malformed initial checkpoint",
+			readCP: func(_ context.Context) ([]byte, error) {
+				return []byte("not-a-valid-checkpoint"), nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := NewReader(ctx, tc.readCP)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NewReader() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			size, err := r.LatestSize(ctx)
+			if err != nil {
+				t.Fatalf("LatestSize() error = %v", err)
+			}
+			if size != tc.wantSize {
+				t.Errorf("LatestSize() = %d, want %d", size, tc.wantSize)
+			}
+		})
+	}
+}
+
+func TestReader_Checkpoint(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		readCP   func(context.Context) ([]byte, error)
+		wantCP   []byte
+		wantSize uint64
+		wantErr  bool
+	}{
+		{
+			name: "successful read and update size",
+			readCP: func(_ context.Context) ([]byte, error) {
+				return mockCheckpoint("test.log", 200), nil
+			},
+			wantCP:   mockCheckpoint("test.log", 200),
+			wantSize: 200,
+		},
+		{
+			name: "storage error does not update size",
+			readCP: func(_ context.Context) ([]byte, error) {
+				return nil, errors.New("network error")
+			},
+			wantSize: 100,
+			wantErr:  true,
+		},
+		{
+			name: "malformed checkpoint does not update size",
+			readCP: func(_ context.Context) ([]byte, error) {
+				return []byte("not-a-valid-checkpoint"), nil
+			},
+			wantSize: 100,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			currentCP := mockCheckpoint("test.log", 100)
+			r, err := NewReader(ctx, func(_ context.Context) ([]byte, error) {
+				return currentCP, nil
+			})
+			if err != nil {
+				t.Fatalf("NewReader() error: %v", err)
+			}
+
+			// Switch read function for subsequent Checkpoint call
+			r.readCheckpoint = tc.readCP
+
+			cp, err := r.Checkpoint(ctx)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Checkpoint() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && !bytes.Equal(cp, tc.wantCP) {
+				t.Errorf("Checkpoint() = %q, want %q", cp, tc.wantCP)
+			}
+
+			size, err := r.LatestSize(ctx)
+			if err != nil {
+				t.Fatalf("LatestSize() error = %v", err)
+			}
+			if size != tc.wantSize {
+				t.Errorf("LatestSize() = %d, want %d", size, tc.wantSize)
+			}
+		})
+	}
+}
+
+func TestReader_LatestSize(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		initialSize   uint64
+		updateSize    uint64 // if > 0, updates checkpoint to updateSize
+		wantSize      uint64
+		wantCallCount int
+	}{
+		{
+			name:          "initial read cached without extra storage calls",
+			initialSize:   100,
+			wantSize:      100,
+			wantCallCount: 1,
+		},
+		{
+			name:          "initial size 0 cached without extra storage calls",
+			initialSize:   0,
+			wantSize:      0,
+			wantCallCount: 1,
+		},
+		{
+			name:          "size updated by checkpoint poll",
+			initialSize:   100,
+			updateSize:    200,
+			wantSize:      200,
+			wantCallCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			callCount := 0
+			currentSize := tc.initialSize
+			readCP := func(_ context.Context) ([]byte, error) {
+				callCount++
+				return mockCheckpoint("test.log", currentSize), nil
+			}
+
+			r, err := NewReader(ctx, readCP)
+			if err != nil {
+				t.Fatalf("NewReader() unexpected error: %v", err)
+			}
+
+			if tc.updateSize > 0 {
+				currentSize = tc.updateSize
+				if _, err := r.Checkpoint(ctx); err != nil {
+					t.Fatalf("Checkpoint() unexpected error: %v", err)
+				}
+			}
+
+			size, err := r.LatestSize(ctx)
+			if err != nil {
+				t.Fatalf("LatestSize() unexpected error: %v", err)
+			}
+			if size != tc.wantSize {
+				t.Errorf("LatestSize() = %d, want %d", size, tc.wantSize)
+			}
+
+			// Subsequent LatestSize call returns cached size without triggering additional storage reads
+			size, err = r.LatestSize(ctx)
+			if err != nil {
+				t.Fatalf("subsequent LatestSize() unexpected error: %v", err)
+			}
+			if size != tc.wantSize {
+				t.Errorf("subsequent LatestSize() = %d, want %d", size, tc.wantSize)
+			}
+			if callCount != tc.wantCallCount {
+				t.Errorf("subsequent callCount = %d, want %d", callCount, tc.wantCallCount)
+			}
+		})
+	}
+}

--- a/cmd/mtc/log/internal/landmark/landmark.go
+++ b/cmd/mtc/log/internal/landmark/landmark.go
@@ -23,7 +23,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/transparency-dev/merkle/proof"
@@ -54,8 +54,8 @@ var (
 	// ErrTooOld indicates that an index precedes the earliest available active landmark.
 	ErrTooOld = errors.New("entry is older than earliest active landmark")
 
-	// ErrNotCovered indicates that an index is not yet covered by any published active landmark.
-	ErrNotCovered = errors.New("entry is not covered by active landmarks")
+	// ErrNotYetCovered indicates that an index is not yet covered by any published active landmark.
+	ErrNotYetCovered = errors.New("entry is not yet covered by active landmarks")
 )
 
 // ReadCheckpointSize returns the current log checkpoint size.
@@ -230,15 +230,15 @@ func (a *ActiveLandmarks) AddLandmark(treeSize, maxActive uint64) error {
 	return nil
 }
 
-// GetSubtreeFor returns the subtree range [start, end) of active landmarks covering index.
+// GetSubtreeFor returns the subtree range [start, end) of the active landmarks covering index.
 // It returns ErrTooOld if index precedes the earliest available active landmark.
-// It returns ErrNotCovered if index is not yet covered by any published active landmark.
+// It returns ErrNotYetCovered if index is not yet covered by any published active landmark.
 func (a *ActiveLandmarks) GetSubtreeFor(index uint64) (start, end uint64, err error) {
 	switch {
 	case len(a.treeSizes) == 0:
-		return 0, 0, errors.New("no landmarks available")
+		return 0, 0, errors.New("no landmarks available but expected at least one")
 	case index >= a.treeSizes[0]:
-		return 0, 0, ErrNotCovered
+		return 0, 0, ErrNotYetCovered
 	case index < a.treeSizes[len(a.treeSizes)-1]:
 		return 0, 0, ErrTooOld
 	}
@@ -265,11 +265,6 @@ func (a *ActiveLandmarks) GetSubtreeFor(index uint64) (start, end uint64, err er
 	return mid, e, nil
 }
 
-type published struct {
-	active *ActiveLandmarks
-	pubAt  time.Time
-}
-
 // Publisher manages publication of the landmarks resource at regular intervals.
 type Publisher struct {
 	storage            LandmarksStorage
@@ -277,7 +272,10 @@ type Publisher struct {
 	maxActive          uint64
 	pubInterval        time.Duration
 
-	published atomic.Pointer[published]
+	// mu protects active and pubAt during concurrent operations
+	mu     sync.RWMutex
+	active ActiveLandmarks // copy of published active landmarks
+	pubAt  time.Time       // time at which active landmarks were last published
 }
 
 // NewPublisher creates a new Publisher instance.
@@ -346,10 +344,10 @@ func (p *Publisher) initialise(ctx context.Context) error {
 		return fmt.Errorf("failed to initialise active landmarks: %w", err)
 	}
 
-	p.published.Store(&published{
-		active: activeLM,
-		pubAt:  modTime,
-	})
+	p.mu.Lock()
+	p.active = *activeLM
+	p.pubAt = modTime
+	p.mu.Unlock()
 	return nil
 }
 
@@ -423,10 +421,10 @@ func (p *Publisher) Update(ctx context.Context) (time.Duration, error) {
 		return 0, fmt.Errorf("failed to update landmarks resource: %v", err)
 	}
 
-	p.published.Store(&published{
-		active: active,
-		pubAt:  modTime,
-	})
+	p.mu.Lock()
+	p.active = *active
+	p.pubAt = modTime
+	p.mu.Unlock()
 
 	next := p.pubInterval
 	if grown {
@@ -445,12 +443,15 @@ func (p *Publisher) Update(ctx context.Context) (time.Duration, error) {
 //   - If index precedes the earliest available active landmark, returns ErrTooOld.
 //   - If index exceeds the current log tree size, it returns an error.
 func (p *Publisher) GetSubtreeFor(ctx context.Context, index uint64) (start, end uint64, retryAfter time.Duration, err error) {
-	pub := p.published.Load()
-	if pub == nil || pub.active == nil {
+	p.mu.RLock()
+	active := p.active
+	pubAt := p.pubAt
+	p.mu.RUnlock()
+	if len(active.treeSizes) == 0 {
 		return 0, 0, p.pubInterval, nil
 	}
 
-	start, end, err = pub.active.GetSubtreeFor(index)
+	start, end, err = active.GetSubtreeFor(index)
 	switch {
 	case err == nil:
 		return start, end, 0, nil
@@ -458,13 +459,13 @@ func (p *Publisher) GetSubtreeFor(ctx context.Context, index uint64) (start, end
 	case errors.Is(err, ErrTooOld):
 		return 0, 0, 0, ErrTooOld
 
-	case errors.Is(err, ErrNotCovered):
+	case errors.Is(err, ErrNotYetCovered):
 		cpSize, err := p.readCheckpointSize(ctx)
 		if err != nil {
 			return 0, 0, 0, fmt.Errorf("read checkpoint size: %w", err)
 		}
 		if index < cpSize {
-			retry := max(time.Millisecond, time.Until(pub.pubAt.Add(p.pubInterval)))
+			retry := max(time.Millisecond, time.Until(pubAt.Add(p.pubInterval)))
 			return 0, 0, retry, nil
 		}
 		return 0, 0, 0, fmt.Errorf("index %d exceeds current log tree size %d", index, cpSize)

--- a/cmd/mtc/log/internal/landmark/landmark.go
+++ b/cmd/mtc/log/internal/landmark/landmark.go
@@ -23,7 +23,10 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
+
+	"github.com/transparency-dev/merkle/proof"
 )
 
 const (
@@ -45,6 +48,14 @@ const (
 	// days, MTC CA landmarks SHOULD be generated approximately every four 4 hours,
 	// and MUST NOT exceed a total of 370 landmarks over any 47-day period."
 	MaxActiveLandmarks = 370
+)
+
+var (
+	// ErrTooOld indicates that an index precedes the earliest available active landmark.
+	ErrTooOld = errors.New("entry is older than earliest active landmark")
+
+	// ErrNotCovered indicates that an index is not yet covered by any published active landmark.
+	ErrNotCovered = errors.New("entry is not covered by active landmarks")
 )
 
 // ReadCheckpointSize returns the current log checkpoint size.
@@ -219,12 +230,54 @@ func (a *ActiveLandmarks) AddLandmark(treeSize, maxActive uint64) error {
 	return nil
 }
 
+// GetSubtreeFor returns the subtree range [start, end) of active landmarks covering index.
+// It returns ErrTooOld if index precedes the earliest available active landmark.
+// It returns ErrNotCovered if index is not yet covered by any published active landmark.
+func (a *ActiveLandmarks) GetSubtreeFor(index uint64) (start, end uint64, err error) {
+	switch {
+	case len(a.treeSizes) == 0:
+		return 0, 0, errors.New("no landmarks available")
+	case index >= a.treeSizes[0]:
+		return 0, 0, ErrNotCovered
+	case index < a.treeSizes[len(a.treeSizes)-1]:
+		return 0, 0, ErrTooOld
+	}
+
+	// Search forward from the most recent landmark (index 0) so recently issued
+	// entries are found immediately in the first iteration.
+	var startLM, endLM uint64
+	for i := 0; i < len(a.treeSizes)-1; i++ {
+		if index >= a.treeSizes[i+1] {
+			endLM = a.treeSizes[i]
+			startLM = a.treeSizes[i+1]
+			break
+		}
+	}
+
+	s, mid, e, err := proof.FindSubtrees(startLM, endLM)
+	if err != nil {
+		return 0, 0, fmt.Errorf("FindSubtrees(%d, %d): %v", startLM, endLM, err)
+	}
+
+	if index < mid {
+		return s, mid, nil
+	}
+	return mid, e, nil
+}
+
+type published struct {
+	active *ActiveLandmarks
+	pubAt  time.Time
+}
+
 // Publisher manages publication of the landmarks resource at regular intervals.
 type Publisher struct {
 	storage            LandmarksStorage
 	readCheckpointSize ReadCheckpointSize
 	maxActive          uint64
 	pubInterval        time.Duration
+
+	published atomic.Pointer[published]
 }
 
 // NewPublisher creates a new Publisher instance.
@@ -279,7 +332,7 @@ func (p *Publisher) initialise(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create initial landmark 0: %w", err)
 	}
-	_, err = p.storage.UpdateLandmarks(ctx, func(old []byte, _ time.Time) ([]byte, error) {
+	modTime, err := p.storage.UpdateLandmarks(ctx, func(old []byte, _ time.Time) ([]byte, error) {
 		if len(old) == 0 {
 			return activeLM.MarshalText()
 		}
@@ -293,6 +346,10 @@ func (p *Publisher) initialise(ctx context.Context) error {
 		return fmt.Errorf("failed to initialise active landmarks: %w", err)
 	}
 
+	p.published.Store(&published{
+		active: activeLM,
+		pubAt:  modTime,
+	})
 	return nil
 }
 
@@ -366,6 +423,11 @@ func (p *Publisher) Update(ctx context.Context) (time.Duration, error) {
 		return 0, fmt.Errorf("failed to update landmarks resource: %v", err)
 	}
 
+	p.published.Store(&published{
+		active: active,
+		pubAt:  modTime,
+	})
+
 	next := p.pubInterval
 	if grown {
 		next = max(time.Millisecond, time.Until(modTime.Add(p.pubInterval)))
@@ -373,4 +435,41 @@ func (p *Publisher) Update(ctx context.Context) (time.Duration, error) {
 
 	slog.DebugContext(ctx, "landmarks update: success", slog.Duration("next-in", next))
 	return next, nil
+}
+
+// GetSubtreeFor returns the subtree range [start, end) of active landmarks covering index.
+//
+//   - If index is not yet in published landmarks but is within the current log
+//     tree size, returns retryAfter > 0 indicating estimated time until the
+//     next landmark publication. This is a best effort estimate.
+//   - If index precedes the earliest available active landmark, returns ErrTooOld.
+//   - If index exceeds the current log tree size, it returns an error.
+func (p *Publisher) GetSubtreeFor(ctx context.Context, index uint64) (start, end uint64, retryAfter time.Duration, err error) {
+	pub := p.published.Load()
+	if pub == nil || pub.active == nil {
+		return 0, 0, p.pubInterval, nil
+	}
+
+	start, end, err = pub.active.GetSubtreeFor(index)
+	switch {
+	case err == nil:
+		return start, end, 0, nil
+
+	case errors.Is(err, ErrTooOld):
+		return 0, 0, 0, ErrTooOld
+
+	case errors.Is(err, ErrNotCovered):
+		cpSize, err := p.readCheckpointSize(ctx)
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("read checkpoint size: %w", err)
+		}
+		if index < cpSize {
+			retry := max(time.Millisecond, time.Until(pub.pubAt.Add(p.pubInterval)))
+			return 0, 0, retry, nil
+		}
+		return 0, 0, 0, fmt.Errorf("index %d exceeds current log tree size %d", index, cpSize)
+
+	default:
+		return 0, 0, 0, err
+	}
 }

--- a/cmd/mtc/log/internal/landmark/landmark.go
+++ b/cmd/mtc/log/internal/landmark/landmark.go
@@ -59,7 +59,7 @@ var (
 )
 
 // ReadCheckpointSize returns the current log checkpoint size.
-type ReadCheckpointSize func(ctx context.Context) (uint64, error)
+type ReadCheckpointSize func() uint64
 
 // LandmarksStorage abstracts reading and writing the published active landmarks resource.
 type LandmarksStorage interface {
@@ -231,12 +231,14 @@ func (a *ActiveLandmarks) AddLandmark(treeSize, maxActive uint64) error {
 }
 
 // GetSubtreeFor returns the subtree range [start, end) of the active landmarks covering index.
+//
 // It returns ErrTooOld if index precedes the earliest available active landmark.
 // It returns ErrNotYetCovered if index is not yet covered by any published active landmark.
+//
+// It assumes that ActiveLandmarks is well-constructed, i.e. treeSizes contains
+// at least one entry, and it is ordered in decreasing order.
 func (a *ActiveLandmarks) GetSubtreeFor(index uint64) (start, end uint64, err error) {
 	switch {
-	case len(a.treeSizes) == 0:
-		return 0, 0, errors.New("no landmarks available but expected at least one")
 	case index >= a.treeSizes[0]:
 		return 0, 0, ErrNotYetCovered
 	case index < a.treeSizes[len(a.treeSizes)-1]:
@@ -382,10 +384,7 @@ func (p *Publisher) start(ctx context.Context) {
 // pubInterval and the checkpoint size has increased.
 // It returns how long to wait before calling Update again.
 func (p *Publisher) Update(ctx context.Context) (time.Duration, error) {
-	cpSize, err := p.readCheckpointSize(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read current checkpoint size: %w", err)
-	}
+	cpSize := p.readCheckpointSize()
 
 	grown := true
 	active := &ActiveLandmarks{}
@@ -460,10 +459,7 @@ func (p *Publisher) GetSubtreeFor(ctx context.Context, index uint64) (start, end
 		return 0, 0, 0, ErrTooOld
 
 	case errors.Is(err, ErrNotYetCovered):
-		cpSize, err := p.readCheckpointSize(ctx)
-		if err != nil {
-			return 0, 0, 0, fmt.Errorf("read checkpoint size: %w", err)
-		}
+		cpSize := p.readCheckpointSize()
 		if index < cpSize {
 			retry := max(time.Millisecond, time.Until(pubAt.Add(p.pubInterval)))
 			return 0, 0, retry, nil

--- a/cmd/mtc/log/internal/landmark/landmark_test.go
+++ b/cmd/mtc/log/internal/landmark/landmark_test.go
@@ -657,7 +657,8 @@ func TestPublisher_GetSubtreeFor(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		published      *published
+		active         *ActiveLandmarks
+		pubAt          time.Time
 		index          uint64
 		wantStart      uint64
 		wantEnd        uint64
@@ -667,32 +668,36 @@ func TestPublisher_GetSubtreeFor(t *testing.T) {
 	}{
 		{
 			name:           "uninitialized published state returns retryAfter",
-			published:      nil,
+			active:         nil,
 			index:          10,
 			wantRetryAfter: true,
 		},
 		{
 			name:      "covered index in active landmark returns subtree range",
-			published: &published{active: mustNew(t, 2, 2, []uint64{100, 50, 0}), pubAt: time.Now()},
+			active:    mustNew(t, 2, 2, []uint64{100, 50, 0}),
+			pubAt:     time.Now(),
 			index:     75,
 			wantStart: 64,
 			wantEnd:   100,
 		},
 		{
 			name:           "in-flight index within tree size returns retryAfter",
-			published:      &published{active: mustNew(t, 2, 2, []uint64{100, 50, 0}), pubAt: time.Now()},
+			active:         mustNew(t, 2, 2, []uint64{100, 50, 0}),
+			pubAt:          time.Now(),
 			index:          120,
 			wantRetryAfter: true,
 		},
 		{
-			name:      "index beyond tree size returns error",
-			published: &published{active: mustNew(t, 2, 2, []uint64{100, 50, 0}), pubAt: time.Now()},
-			index:     160,
-			wantErr:   true,
+			name:    "index beyond tree size returns error",
+			active:  mustNew(t, 2, 2, []uint64{100, 50, 0}),
+			pubAt:   time.Now(),
+			index:   160,
+			wantErr: true,
 		},
 		{
 			name:          "pruned index older than oldest active landmark returns ErrTooOld",
-			published:     &published{active: mustNew(t, 3, 2, []uint64{150, 100, 50}), pubAt: time.Now()},
+			active:        mustNew(t, 3, 2, []uint64{150, 100, 50}),
+			pubAt:         time.Now(),
 			index:         25,
 			wantErrTooOld: true,
 		},
@@ -700,7 +705,14 @@ func TestPublisher_GetSubtreeFor(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			pub.published.Store(tc.published)
+			pub.mu.Lock()
+			if tc.active != nil {
+				pub.active = *tc.active
+			} else {
+				pub.active = ActiveLandmarks{}
+			}
+			pub.pubAt = tc.pubAt
+			pub.mu.Unlock()
 
 			s, e, retry, err := pub.GetSubtreeFor(ctx, tc.index)
 			if tc.wantErrTooOld {

--- a/cmd/mtc/log/internal/landmark/landmark_test.go
+++ b/cmd/mtc/log/internal/landmark/landmark_test.go
@@ -17,6 +17,7 @@ package landmark
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"reflect"
 	"sync"
@@ -250,6 +251,81 @@ func TestAddLandmark(t *testing.T) {
 	// Adding landmark with maxActive 0 should fail
 	if err := lm.AddLandmark(400, 0); err == nil {
 		t.Errorf("AddLandmark(400, 0) expected error for maxActive == 0, got nil")
+	}
+}
+
+func TestActiveLandmarks_GetSubtreeFor(t *testing.T) {
+	tests := []struct {
+		name      string
+		landmarks *ActiveLandmarks
+		index     uint64
+		wantStart uint64
+		wantEnd   uint64
+		wantErr   bool
+	}{
+		{
+			name:      "uninitialized landmarks",
+			landmarks: &ActiveLandmarks{},
+			index:     10,
+			wantErr:   true,
+		},
+		{
+			name:      "index too old (pruned)",
+			landmarks: mustNew(t, 3, 2, []uint64{150, 100, 50}),
+			index:     25,
+			wantErr:   true,
+		},
+		{
+			name:      "index not covered (exceeds latest landmark)",
+			landmarks: mustNew(t, 3, 3, []uint64{150, 100, 50, 0}),
+			index:     160,
+			wantErr:   true,
+		},
+		{
+			name:      "index 25 in landmark [0, 50)",
+			landmarks: mustNew(t, 3, 3, []uint64{150, 100, 50, 0}),
+			index:     25,
+			wantStart: 0,
+			wantEnd:   32,
+		},
+		{
+			name:      "index 40 in landmark [0, 50)",
+			landmarks: mustNew(t, 3, 3, []uint64{150, 100, 50, 0}),
+			index:     40,
+			wantStart: 32,
+			wantEnd:   50,
+		},
+		{
+			name:      "index 75 in landmark [50, 100)",
+			landmarks: mustNew(t, 3, 3, []uint64{150, 100, 50, 0}),
+			index:     75,
+			wantStart: 64,
+			wantEnd:   100,
+		},
+		{
+			name:      "index 130 in landmark [100, 150)",
+			landmarks: mustNew(t, 3, 3, []uint64{150, 100, 50, 0}),
+			index:     130,
+			wantStart: 128,
+			wantEnd:   150,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, e, err := tc.landmarks.GetSubtreeFor(tc.index)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("GetSubtreeFor(%d) error = %v, wantErr %v", tc.index, err, tc.wantErr)
+			}
+			if !tc.wantErr {
+				if s != tc.wantStart || e != tc.wantEnd {
+					t.Errorf("GetSubtreeFor(%d) = [%d, %d), want [%d, %d)", tc.index, s, e, tc.wantStart, tc.wantEnd)
+				}
+				if tc.index < s || tc.index >= e {
+					t.Errorf("GetSubtreeFor(%d) returned range [%d, %d) that does not contain index", tc.index, s, e)
+				}
+			}
+		})
 	}
 }
 
@@ -568,5 +644,95 @@ func TestNewPublisher(t *testing.T) {
 	}
 }
 
+func TestPublisher_GetSubtreeFor(t *testing.T) {
+	ctx := context.Background()
+	treeSize := uint64(150)
+	pubInterval := 1 * time.Hour
+	memStorage := &mockStorage{}
 
+	pub, err := NewPublisher(ctx, func(ctx context.Context) (uint64, error) { return treeSize, nil }, memStorage, 24*time.Hour, pubInterval)
+	if err != nil {
+		t.Fatalf("NewPublisher() error: %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		published      *published
+		index          uint64
+		wantStart      uint64
+		wantEnd        uint64
+		wantRetryAfter bool
+		wantErrTooOld  bool
+		wantErr        bool
+	}{
+		{
+			name:           "uninitialized published state returns retryAfter",
+			published:      nil,
+			index:          10,
+			wantRetryAfter: true,
+		},
+		{
+			name:      "covered index in active landmark returns subtree range",
+			published: &published{active: mustNew(t, 2, 2, []uint64{100, 50, 0}), pubAt: time.Now()},
+			index:     75,
+			wantStart: 64,
+			wantEnd:   100,
+		},
+		{
+			name:           "in-flight index within tree size returns retryAfter",
+			published:      &published{active: mustNew(t, 2, 2, []uint64{100, 50, 0}), pubAt: time.Now()},
+			index:          120,
+			wantRetryAfter: true,
+		},
+		{
+			name:      "index beyond tree size returns error",
+			published: &published{active: mustNew(t, 2, 2, []uint64{100, 50, 0}), pubAt: time.Now()},
+			index:     160,
+			wantErr:   true,
+		},
+		{
+			name:          "pruned index older than oldest active landmark returns ErrTooOld",
+			published:     &published{active: mustNew(t, 3, 2, []uint64{150, 100, 50}), pubAt: time.Now()},
+			index:         25,
+			wantErrTooOld: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pub.published.Store(tc.published)
+
+			s, e, retry, err := pub.GetSubtreeFor(ctx, tc.index)
+			if tc.wantErrTooOld {
+				if !errors.Is(err, ErrTooOld) {
+					t.Fatalf("GetSubtreeFor(%d) error = %v, want %v", tc.index, err, ErrTooOld)
+				}
+				return
+			}
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("GetSubtreeFor(%d) expected error, got nil", tc.index)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetSubtreeFor(%d) unexpected error: %v", tc.index, err)
+			}
+
+			if tc.wantRetryAfter {
+				if retry <= 0 {
+					t.Errorf("GetSubtreeFor(%d) retry = %v, want > 0", tc.index, retry)
+				}
+				return
+			}
+
+			if retry != 0 {
+				t.Errorf("GetSubtreeFor(%d) retry = %v, want 0", tc.index, retry)
+			}
+			if s != tc.wantStart || e != tc.wantEnd {
+				t.Errorf("GetSubtreeFor(%d) = [%d, %d), want [%d, %d)", tc.index, s, e, tc.wantStart, tc.wantEnd)
+			}
+		})
+	}
+}
 

--- a/cmd/mtc/log/internal/landmark/landmark_test.go
+++ b/cmd/mtc/log/internal/landmark/landmark_test.go
@@ -264,12 +264,6 @@ func TestActiveLandmarks_GetSubtreeFor(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:      "uninitialized landmarks",
-			landmarks: &ActiveLandmarks{},
-			index:     10,
-			wantErr:   true,
-		},
-		{
 			name:      "index too old (pruned)",
 			landmarks: mustNew(t, 3, 2, []uint64{150, 100, 50}),
 			index:     25,
@@ -390,7 +384,7 @@ func TestPublisher_Initialise(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			loopCtx, cancelLoop := context.WithCancel(ctx)
 			memStorage := &mockStorage{data: tc.initialData}
-			_, err := NewPublisher(loopCtx, func(ctx context.Context) (uint64, error) { return 0, nil }, memStorage, 24*time.Hour, 1*time.Hour)
+			_, err := NewPublisher(loopCtx, func() uint64 { return 0 }, memStorage, 24*time.Hour, 1*time.Hour)
 			if err != nil {
 				t.Fatalf("NewPublisher() error: %v", err)
 			}
@@ -415,8 +409,8 @@ func TestPublisher_Update(t *testing.T) {
 	ctx := context.Background()
 	loopCtx, cancelLoop := context.WithCancel(ctx)
 	currentSize := uint64(0)
-	readCheckpointSize := func(ctx context.Context) (uint64, error) {
-		return currentSize, nil
+	readCheckpointSize := func() uint64 {
+		return currentSize
 	}
 
 	memStorage := &mockStorage{}
@@ -521,7 +515,7 @@ func TestNewPublisher(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	dummyReader := func(ctx context.Context) (uint64, error) { return 0, nil }
+	dummyReader := func() uint64 { return 0 }
 	dummyStorage := &mockStorage{}
 
 	tests := []struct {
@@ -650,7 +644,7 @@ func TestPublisher_GetSubtreeFor(t *testing.T) {
 	pubInterval := 1 * time.Hour
 	memStorage := &mockStorage{}
 
-	pub, err := NewPublisher(ctx, func(ctx context.Context) (uint64, error) { return treeSize, nil }, memStorage, 24*time.Hour, pubInterval)
+	pub, err := NewPublisher(ctx, func() uint64 { return treeSize }, memStorage, 24*time.Hour, pubInterval)
 	if err != nil {
 		t.Fatalf("NewPublisher() error: %v", err)
 	}
@@ -747,4 +741,3 @@ func TestPublisher_GetSubtreeFor(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -26,9 +26,9 @@ import (
 
 	"github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/checkpoint"
 	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/entry"
 	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/landmark"
-	"github.com/transparency-dev/tessera/internal/parse"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 )
@@ -196,7 +196,7 @@ func parseValidity(data []byte) (validity, error) {
 	var v validity
 	rest, err := stdasn1.Unmarshal(data, &v)
 	if err != nil {
-		return validity{}, fmt.Errorf("unmarshal validity: %w", err)
+		return validity{}, fmt.Errorf("unmarshal validity: %v", err)
 	}
 	if len(rest) > 0 {
 		return validity{}, errors.New("trailing bytes in validity SEQUENCE")
@@ -342,24 +342,6 @@ func (l *MTCLog) accept(tbs TBSCertificateLogEntry) error {
 	return nil
 }
 
-func (l *MTCLog) readCheckpointSize(ctx context.Context) (uint64, error) {
-	if l.reader == nil {
-		return 0, errors.New("log reader is not configured")
-	}
-
-	rawCp, err := l.reader.ReadCheckpoint(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("read checkpoint: %w", err)
-	}
-
-	_, size, _, err := parse.CheckpointUnsafe(rawCp)
-	if err != nil {
-		return 0, fmt.Errorf("parse checkpoint: %w", err)
-	}
-
-	return size, nil
-}
-
 // NewMTCLog creates a new MTCLog compliant with
 // draft-ietf-plants-merkle-tree-certs and http://c2sp.org/mtc-tlog.
 func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog, error) {
@@ -373,11 +355,9 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 		return nil, err
 	}
 
-	l := &MTCLog{
-		a:               a,
-		reader:          opts.reader,
-		awaiter:         tessera.NewPublicationAwaiter(ctx, opts.reader.ReadCheckpoint, opts.pollPeriod),
-		maxCertLifetime: opts.maxCertLifetime,
+	cpReader, err := checkpoint.NewReader(ctx, opts.reader.ReadCheckpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read initial checkpoint: %v", err)
 	}
 
 	interval := opts.landmarkInterval
@@ -390,13 +370,18 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 		)
 	}
 
-	pub, err := landmark.NewPublisher(ctx, l.readCheckpointSize, opts.landmarkStorage, opts.maxCertLifetime, interval)
+	pub, err := landmark.NewPublisher(ctx, cpReader.LatestSize, opts.landmarkStorage, opts.maxCertLifetime, interval)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialise landmark publisher: %v", err)
 	}
-	l.landmarkPublisher = pub
 
-	return l, nil
+	return &MTCLog{
+		a:                 a,
+		reader:            opts.reader,
+		awaiter:           tessera.NewPublicationAwaiter(ctx, cpReader.Checkpoint, opts.pollPeriod),
+		landmarkPublisher: pub,
+		maxCertLifetime:   opts.maxCertLifetime,
+	}, nil
 }
 
 // AddTBS adds a TBSCertificateLogEntry to the log.

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -392,7 +392,7 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 
 	pub, err := landmark.NewPublisher(ctx, l.readCheckpointSize, opts.landmarkStorage, opts.maxCertLifetime, interval)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialise landmark publisher: %w", err)
+		return nil, fmt.Errorf("failed to initialise landmark publisher: %v", err)
 	}
 	l.landmarkPublisher = pub
 

--- a/cmd/mtc/log/mtc_test.go
+++ b/cmd/mtc/log/mtc_test.go
@@ -367,7 +367,7 @@ func TestMTCLog_Accept(t *testing.T) {
 type dummyLogReader struct{ tessera.LogReader }
 
 func (dummyLogReader) ReadCheckpoint(context.Context) ([]byte, error) {
-	return nil, nil
+	return []byte("test.origin\n0\nAAAA\n"), nil
 }
 
 type dummyLandmarksStorage struct{}


### PR DESCRIPTION
Towards #945.

This PR introduces `GetSubtreeFor(index)` methods, which we'll use later on to build Landmark relative inclusion proofs.

It also adds a new `checkpoint` package, which takes care of fetching checkpoints, and caching their size. This package will be expanded later, to cache subtree boundaries, which we'll need later for `AddTBS()`.