### PR TITLE
Use mirror witness for add-entries checkpoint signatures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/rivo/tview v0.42.0
 	github.com/transparency-dev/formats v0.1.2-0.20260805102052-38e6e69c4152
 	github.com/transparency-dev/merkle v0.0.3-0.20260727102338-4491f478b7dc
-	github.com/transparency-dev/witness v0.0.0-20260811161034-ce89de7de1be
+	github.com/transparency-dev/witness v0.0.0-20260813093658-47c5c1d9be75
 	go.opentelemetry.io/contrib/detectors/aws/ec2/v2 v2.5.2
 	go.opentelemetry.io/contrib/detectors/aws/ecs v1.45.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,8 @@ github.com/transparency-dev/merkle v0.0.3-0.20260727102338-4491f478b7dc h1:DaUOz
 github.com/transparency-dev/merkle v0.0.3-0.20260727102338-4491f478b7dc/go.mod h1:E+iHk6bS+tIgIJGD4TMeAjSjhQ9wPfL/ST4pXyITjdU=
 github.com/transparency-dev/witness v0.0.0-20260811161034-ce89de7de1be h1:gIpR+JFv5Y5iaH7tGsXN2roK+nn26wdUegVjf5luVqg=
 github.com/transparency-dev/witness v0.0.0-20260811161034-ce89de7de1be/go.mod h1:8kubNAzXuDgpH+SPlC+yQn+3GYeEBvOknjv5fpFWEMk=
+github.com/transparency-dev/witness v0.0.0-20260813093658-47c5c1d9be75 h1:+L3Q80ou3Yg9Q7klW5C+l07N5WSkFh647UMtQgptgeM=
+github.com/transparency-dev/witness v0.0.0-20260813093658-47c5c1d9be75/go.mod h1:PO4JoQYLy1w5xaSo5EYqhY996O+VnWdg3sMBuzeH1q0=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -375,15 +375,6 @@ func (mt *MirrorTarget) publishCheckpoint(ctx context.Context, newCP []byte, new
 		return nil, 0, fmt.Errorf("failed to create proof builder: %w", err)
 	}
 
-	oldSize := mt.oldSize.Load()
-	var cProof [][]byte
-	if oldSize > 0 {
-		cProof, err = pb.ConsistencyProof(ctx, oldSize, newCPSize)
-		if err != nil {
-			return nil, 0, fmt.Errorf("failed to get consistency proof: %w", err)
-		}
-	}
-
 	// SPEC: Finally, the mirror performs the following steps atomically. Note the mirror
 	// 			checkpoint may have changed since the start of this process.
 	//  			- Check if upload_end is still greater than or equal to the mirror checkpoint's tree size.
@@ -395,22 +386,29 @@ func (mt *MirrorTarget) publishCheckpoint(ctx context.Context, newCP []byte, new
 	// 			response: a sequence of one or more note signature lines.
 	var wSigs []byte
 	for done := false; !done; {
+		oldSize := mt.oldSize.Load()
 		var wSize uint64
+		var cProof [][]byte
+		if oldSize > 0 {
+			cProof, err = pb.ConsistencyProof(ctx, oldSize, newCPSize)
+			if err != nil {
+				return nil, 0, fmt.Errorf("failed to get consistency proof: %w", err)
+			}
+		}
 		wSigs, wSize, err = mt.mirrorWitness.Update(ctx, oldSize, newCP, cProof)
 		if err != nil {
 			if errors.Is(err, witness.ErrCheckpointStale) {
-				slog.WarnContext(ctx, "Retrying stale checkpoint on mirror witness", slog.Uint64("oldSize", oldSize), slog.Uint64("newSize", wSize))
-				oldSize = wSize
+				slog.DebugContext(ctx, "Retrying stale checkpoint on mirror witness", slog.Uint64("oldSize", oldSize), slog.Uint64("wSize", wSize))
+				mt.oldSize.CompareAndSwap(oldSize, wSize)
 				continue
 			}
-			slog.WarnContext(ctx, "Permanent failure updating checkpoint on mirror witness", slog.Uint64("oldSize", oldSize), slog.Uint64("newSize", wSize), slog.Any("error", err))
+			slog.WarnContext(ctx, "Permanent failure updating checkpoint on mirror witness", slog.Uint64("oldSize", oldSize), slog.Uint64("newCPSize", newCPSize), slog.Uint64("wSize", wSize), slog.String("error", err.Error()))
 			return nil, wSize, fmt.Errorf("failed to update checkpoint: %w", err)
 		}
 		done = true
+		mt.oldSize.CompareAndSwap(oldSize, newCPSize)
+		slog.InfoContext(ctx, "Completed upload", slog.Uint64("oldSize", oldSize), slog.Uint64("newSize", newCPSize))
 	}
-	mt.oldSize.CompareAndSwap(oldSize, newCPSize)
-
-	slog.WarnContext(ctx, "Completed upload", slog.Uint64("oldSize", oldSize), slog.Uint64("newSize", newCPSize))
 
 	return wSigs, newCPSize, nil
 }
@@ -429,18 +427,20 @@ func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []by
 		return 0, 0, false, nil, nil, nil, fmt.Errorf("failed to read integrated size: %v", err)
 	}
 
-	var pendingCP *log.Checkpoint
-	userTicketValid := false
+	var (
+		pendingCP       *log.Checkpoint
+		pendingCPRaw    []byte
+		userTicketValid bool
+	)
 
-	var ticketCP []byte
 	if len(ticketBytes) > 0 {
-		ticketCP, err = mt.open(ticketBytes)
+		pendingCPRaw, err = mt.open(ticketBytes)
 		if err != nil {
-			slog.DebugContext(ctx, "Failed to open ticket", slog.Any("error", err))
+			slog.WarnContext(ctx, "Failed to open ticket", slog.Any("error", err))
 		} else {
-			pendingCP, _, _, err = log.ParseCheckpoint(ticketCP, mt.origin, mt.logVerifier)
+			pendingCP, _, _, err = log.ParseCheckpoint(pendingCPRaw, mt.origin, mt.logVerifier)
 			if err != nil {
-				slog.DebugContext(ctx, "Failed to parse ticket", slog.Any("error", err))
+				slog.DebugContext(ctx, "Failed to parse ticket checkpoint", slog.Any("error", err))
 			} else {
 				slog.DebugContext(ctx, "Valid ticket", slog.Uint64("nextEntry", nextEntry), slog.Uint64("pendingSize", pendingCP.Size))
 				userTicketValid = true
@@ -449,19 +449,19 @@ func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []by
 	}
 
 	if pendingCP == nil || pendingCP.Size != expectedSize {
-		slog.DebugContext(ctx, "Invalid or incorrect ticket, returning new ticket", slog.Uint64("next_entry", nextEntry), slog.String("ticketCP", string(ticketCP)), slog.Uint64("expectedSize", expectedSize))
-		ticketBytes, pendingCP, ticketCP, err = mt.createNewTicket(ctx)
+		slog.DebugContext(ctx, "Invalid or incorrect ticket, returning new ticket", slog.Uint64("next_entry", nextEntry), slog.String("ticketCP", string(pendingCPRaw)), slog.Uint64("expectedSize", expectedSize))
+		ticketBytes, pendingCP, pendingCPRaw, err = mt.createNewTicket(ctx)
 		if err != nil {
 			return 0, 0, userTicketValid, nil, nil, nil, fmt.Errorf("failed to create new ticket: %w", err)
 		}
 		// If the new pending checkpoint still doesn't match expectedSize, return 409 Conflict with the fresh ticket.
 		if pendingCP.Size != expectedSize {
-			return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, ticketCP, ErrConflict
+			return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, pendingCPRaw, ErrConflict
 		}
 		// Otherwise, allow the request to continue (because their uploadEnd == pendingCP.Size).
 	}
 
-	return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, ticketCP, nil
+	return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, pendingCPRaw, nil
 }
 
 func (mt *MirrorTarget) createNewTicket(ctx context.Context) (ticket []byte, pendingCP *log.Checkpoint, pendingRaw []byte, err error) {

--- a/mirror_lifecycle.go
+++ b/mirror_lifecycle.go
@@ -21,17 +21,13 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/base64"
-	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"iter"
 	"log/slog"
-	"strings"
-	"unicode"
-	"unicode/utf8"
+	"sync/atomic"
 
 	"github.com/transparency-dev/formats/log"
 	fnote "github.com/transparency-dev/formats/note"
@@ -41,7 +37,7 @@ import (
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api"
 	"github.com/transparency-dev/tessera/api/layout"
-	"github.com/transparency-dev/witness/persistence/inmemory"
+	"github.com/transparency-dev/tessera/client"
 	"github.com/transparency-dev/witness/witness"
 	"golang.org/x/mod/sumdb/note"
 )
@@ -154,7 +150,8 @@ type MirrorTarget struct {
 	signer             fnote.SubtreeSigner
 	logVerifier        note.Verifier
 	verifySubtreeProof func(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot []byte, root []byte) error
-	signSubtree        signSubtreeFunc
+	mirrorWitness      *witness.Witness
+	oldSize            *atomic.Uint64
 	ticketKey          []byte
 }
 
@@ -184,7 +181,7 @@ func NewMirrorTarget(ctx context.Context, d Driver, opts *MirrorOptions) (*Mirro
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive ticket key: %v", err)
 	}
-	signSubtree, err := subtreeWitness(ctx, opts)
+	mirrorWitness, err := subtreeWitness(ctx, r, mw, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create subtree witness: %v", err)
 	}
@@ -196,7 +193,8 @@ func NewMirrorTarget(ctx context.Context, d Driver, opts *MirrorOptions) (*Mirro
 		logVerifier:        opts.logVerifier,
 		origin:             opts.origin,
 		verifySubtreeProof: proof.VerifySubtreeConsistency,
-		signSubtree:        signSubtree,
+		mirrorWitness:      mirrorWitness,
+		oldSize:            &atomic.Uint64{},
 		ticketKey:          tK,
 	}, nil
 }
@@ -238,7 +236,7 @@ type MirrorPackage struct {
 // - an opaque ticket for future invocation,
 // - optionally, a cosignature over a pending checkpoint whose size matches uploadEnd if one exists.
 func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticketBytes []byte, next func() (*MirrorPackage, error)) (uint64, uint64, []byte, []byte, error) {
-	nextEntry, pendingSize, userTicketValid, ticketBytes, pendingCP, pendingNote, err := mt.openOrCreateTicket(ctx, ticketBytes, uploadEnd)
+	nextEntry, pendingSize, userTicketValid, ticketBytes, pendingCP, pendingRaw, err := mt.openOrCreateTicket(ctx, ticketBytes, uploadEnd)
 	if err != nil {
 		return nextEntry, pendingSize, ticketBytes, nil, err
 	}
@@ -266,12 +264,12 @@ func (mt *MirrorTarget) AddEntries(ctx context.Context, uploadStart, uploadEnd u
 		return 0, 0, nil, nil, err
 	case nextEntry == pendingSize:
 		if !bytes.Equal(pendingCP.Hash, newRoot) {
-			slog.ErrorContext(ctx, "CORRUPTION DETECTED - pending root != calculated root", slog.String("calculated_root", hex.EncodeToString(newRoot)), slog.String("pending_checkpoint", string(pendingNote.Text)))
+			slog.ErrorContext(ctx, "CORRUPTION DETECTED - pending root != calculated root", slog.String("calculated_root", hex.EncodeToString(newRoot)), slog.String("pending_checkpoint", string(pendingRaw)))
 			return 0, 0, nil, nil, errors.New("internal error")
 		}
 
 		// This is a complete upload.
-		sigs, pubSize, err := mt.publishCheckpoint(ctx, pendingCP, pendingNote)
+		sigs, pubSize, err := mt.publishCheckpoint(ctx, pendingRaw, pendingCP.Size)
 		if err != nil {
 			return nextEntry, pubSize, nil, nil, fmt.Errorf("publishCheckpoint %w", err) // %w as we may need to signal ErrConflict.
 		}
@@ -371,47 +369,50 @@ func (mt *MirrorTarget) bundleIterator(ctx context.Context, next func() (*Mirror
 }
 
 // publishCheckpoint attempts to sign and atomically publish the provided checkpoint.
-func (mt *MirrorTarget) publishCheckpoint(ctx context.Context, newCP *log.Checkpoint, cpNote *note.Note) ([]byte, uint64, error) {
-	var retSigs []byte
-	retSize := newCP.Size
-
-	if err := mt.writer.UpdateCheckpoint(ctx, func(oldCP []byte) ([]byte, error) {
-		// SPEC: Finally, the mirror performs the following steps atomically. Note the mirror
-		// 			checkpoint may have changed since the start of this process.
-		//  			- Check if upload_end is still greater than or equal to the mirror checkpoint's tree size.
-		// 				- If so, update the mirror checkpoint to the pending checkpoint of size upload_end.
-		// 			If upload_end was too small, the mirror MUST respond with a "409 Conflict" HTTP status
-		//    	code, [with approriate response body].
-		// 			Otherwise, if the mirror checkpoint was updated, the mirror MUST respond with a "200 Success"
-		// 			HTTP status code. The response body MUST be formatted as in a witness's successful add-checkpoint
-		// 			response: a sequence of one or more note signature lines.
-		if len(oldCP) > 0 {
-			publishedCP, _, _, err := log.ParseCheckpoint(oldCP, mt.origin, mt.logVerifier)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse published checkpoint: %v", err)
-			}
-			if publishedCP.Origin != newCP.Origin {
-				return nil, fmt.Errorf("published CP origin %q != new CP origin %q", publishedCP.Origin, newCP.Origin)
-			}
-			if publishedCP.Size > newCP.Size {
-				// Return the larger size so that the caller re-syncs.
-				retSize = publishedCP.Size
-				return nil, ErrConflict
-			}
-		}
-		signedNewCPRaw, sigs, err := signNote(cpNote, mt.signer)
-		if err != nil {
-			return nil, fmt.Errorf("failed to cosign pending checkpoint: %v", err)
-		}
-
-		retSigs = sigs
-
-		return signedNewCPRaw, nil
-	}); err != nil {
-		return nil, retSize, fmt.Errorf("failed to update checkpoint: %w", err)
+func (mt *MirrorTarget) publishCheckpoint(ctx context.Context, newCP []byte, newCPSize uint64) ([]byte, uint64, error) {
+	pb, err := client.NewProofBuilder(ctx, newCPSize, mt.reader.ReadTile)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create proof builder: %w", err)
 	}
 
-	return retSigs, retSize, nil
+	oldSize := mt.oldSize.Load()
+	var cProof [][]byte
+	if oldSize > 0 {
+		cProof, err = pb.ConsistencyProof(ctx, oldSize, newCPSize)
+		if err != nil {
+			return nil, 0, fmt.Errorf("failed to get consistency proof: %w", err)
+		}
+	}
+
+	// SPEC: Finally, the mirror performs the following steps atomically. Note the mirror
+	// 			checkpoint may have changed since the start of this process.
+	//  			- Check if upload_end is still greater than or equal to the mirror checkpoint's tree size.
+	// 				- If so, update the mirror checkpoint to the pending checkpoint of size upload_end.
+	// 			If upload_end was too small, the mirror MUST respond with a "409 Conflict" HTTP status
+	//    	code, [with approriate response body].
+	// 			Otherwise, if the mirror checkpoint was updated, the mirror MUST respond with a "200 Success"
+	// 			HTTP status code. The response body MUST be formatted as in a witness's successful add-checkpoint
+	// 			response: a sequence of one or more note signature lines.
+	var wSigs []byte
+	for done := false; !done; {
+		var wSize uint64
+		wSigs, wSize, err = mt.mirrorWitness.Update(ctx, oldSize, newCP, cProof)
+		if err != nil {
+			if errors.Is(err, witness.ErrCheckpointStale) {
+				slog.WarnContext(ctx, "Retrying stale checkpoint on mirror witness", slog.Uint64("oldSize", oldSize), slog.Uint64("newSize", wSize))
+				oldSize = wSize
+				continue
+			}
+			slog.WarnContext(ctx, "Permanent failure updating checkpoint on mirror witness", slog.Uint64("oldSize", oldSize), slog.Uint64("newSize", wSize), slog.Any("error", err))
+			return nil, wSize, fmt.Errorf("failed to update checkpoint: %w", err)
+		}
+		done = true
+	}
+	mt.oldSize.CompareAndSwap(oldSize, newCPSize)
+
+	slog.WarnContext(ctx, "Completed upload", slog.Uint64("oldSize", oldSize), slog.Uint64("newSize", newCPSize))
+
+	return wSigs, newCPSize, nil
 }
 
 // IntegratedSize returns the size of the current integrated log.
@@ -422,14 +423,13 @@ func (mt *MirrorTarget) IntegratedSize(ctx context.Context) (uint64, error) {
 // openOrCreateTicket handles ticket logic, returning a new ticket if the provided one is invalid/missing.
 //
 // Returns next entry index to upload, size of the pending checkpoint, a bool indicating whether the provided ticket was valid, the ticket to return to the caller (may be the same as the provided one), pending checkpoint structure, pending note, and error.
-func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []byte, expectedSize uint64) (uint64, uint64, bool, []byte, *log.Checkpoint, *note.Note, error) {
+func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []byte, expectedSize uint64) (uint64, uint64, bool, []byte, *log.Checkpoint, []byte, error) {
 	nextEntry, err := mt.reader.IntegratedSize(ctx)
 	if err != nil {
 		return 0, 0, false, nil, nil, nil, fmt.Errorf("failed to read integrated size: %v", err)
 	}
 
 	var pendingCP *log.Checkpoint
-	var pendingNote *note.Note
 	userTicketValid := false
 
 	var ticketCP []byte
@@ -438,7 +438,7 @@ func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []by
 		if err != nil {
 			slog.DebugContext(ctx, "Failed to open ticket", slog.Any("error", err))
 		} else {
-			pendingCP, _, pendingNote, err = log.ParseCheckpoint(ticketCP, mt.origin, mt.logVerifier)
+			pendingCP, _, _, err = log.ParseCheckpoint(ticketCP, mt.origin, mt.logVerifier)
 			if err != nil {
 				slog.DebugContext(ctx, "Failed to parse ticket", slog.Any("error", err))
 			} else {
@@ -450,21 +450,21 @@ func (mt *MirrorTarget) openOrCreateTicket(ctx context.Context, ticketBytes []by
 
 	if pendingCP == nil || pendingCP.Size != expectedSize {
 		slog.DebugContext(ctx, "Invalid or incorrect ticket, returning new ticket", slog.Uint64("next_entry", nextEntry), slog.String("ticketCP", string(ticketCP)), slog.Uint64("expectedSize", expectedSize))
-		ticketBytes, pendingCP, pendingNote, err = mt.createNewTicket(ctx)
+		ticketBytes, pendingCP, ticketCP, err = mt.createNewTicket(ctx)
 		if err != nil {
 			return 0, 0, userTicketValid, nil, nil, nil, fmt.Errorf("failed to create new ticket: %w", err)
 		}
 		// If the new pending checkpoint still doesn't match expectedSize, return 409 Conflict with the fresh ticket.
 		if pendingCP.Size != expectedSize {
-			return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, pendingNote, ErrConflict
+			return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, ticketCP, ErrConflict
 		}
 		// Otherwise, allow the request to continue (because their uploadEnd == pendingCP.Size).
 	}
 
-	return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, pendingNote, nil
+	return nextEntry, pendingCP.Size, userTicketValid, ticketBytes, pendingCP, ticketCP, nil
 }
 
-func (mt *MirrorTarget) createNewTicket(ctx context.Context) (ticket []byte, pendingCP *log.Checkpoint, pendingNote *note.Note, err error) {
+func (mt *MirrorTarget) createNewTicket(ctx context.Context) (ticket []byte, pendingCP *log.Checkpoint, pendingRaw []byte, err error) {
 	pendingCPRaw, err := mt.cpSource(ctx)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to get pending checkpoint: %v", err)
@@ -472,7 +472,7 @@ func (mt *MirrorTarget) createNewTicket(ctx context.Context) (ticket []byte, pen
 	if len(pendingCPRaw) == 0 {
 		return nil, nil, nil, ErrNoPendingCheckpoint
 	}
-	pendingCP, _, pendingNote, err = log.ParseCheckpoint(pendingCPRaw, mt.origin, mt.logVerifier)
+	pendingCP, _, _, err = log.ParseCheckpoint(pendingCPRaw, mt.origin, mt.logVerifier)
 	if err != nil {
 		slog.ErrorContext(ctx, "Invalid pending checkpoint from source", slog.String("pending_checkpoint", string(pendingCPRaw)), slog.String("error", err.Error()))
 		return nil, nil, nil, fmt.Errorf("failed to parse pending checkpoint while creating ticket: %v", err)
@@ -481,7 +481,7 @@ func (mt *MirrorTarget) createNewTicket(ctx context.Context) (ticket []byte, pen
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to create ticket: %v", err)
 	}
-	return ticket, pendingCP, pendingNote, nil
+	return ticket, pendingCP, pendingCPRaw, nil
 }
 
 func (mt *MirrorTarget) seal(b []byte) ([]byte, error) {
@@ -508,80 +508,18 @@ func (mt *MirrorTarget) open(sealed []byte) ([]byte, error) {
 
 // SignSubtree returns a cosignature for a subtree of the mirrored log.
 func (mt *MirrorTarget) SignSubtree(ctx context.Context, start, end uint64, subRoot []byte, proof [][]byte, cp []byte) ([]byte, error) {
-	return mt.signSubtree(ctx, start, end, subRoot, proof, cp)
+	return mt.mirrorWitness.SignSubtree(ctx, start, end, subRoot, proof, cp)
 }
 
-func signNote(n *note.Note, signers ...note.Signer) ([]byte, []byte, error) {
-	// Code below is a lightly tweaked snippet from sumdb/note/note.go
-	// https://cs.opensource.google/go/x/mod/+/refs/tags/v0.24.0:sumdb/note/note.go;l=625-649
-
-	// Prepare signatures.
-	//
-	// We need to return both a full serialised signed note, as well as the just the
-	// signature lines we're adding - this is because we want to _store_ the full note, but
-	// the tlog-witness API requires that we only return the signature lines.
-	//
-	// Rather than using note.Sign, then running note.Open in order to get access to our
-	// signatures, we'll instead use our note.Signer(s) directly to sign the note message
-	// and then use the returned signature bytes to create both the serialised signed note
-	// as well as the serialised signature lines.
-
-	var sigs = bytes.Buffer{}
-	for _, s := range signers {
-		name := s.Name()
-		hash := s.KeyHash()
-		if !isValidSignerName(name) {
-			return nil, nil, errors.New("invalid signer")
-		}
-
-		sig, err := s.Sign([]byte(n.Text))
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// Create serialised signature line and append it to our sigs buffer:
-		var hbuf [4]byte
-		binary.BigEndian.PutUint32(hbuf[:], hash)
-		b64 := base64.StdEncoding.EncodeToString(append(hbuf[:], sig...))
-		sigs.WriteString("— ")
-		sigs.WriteString(name)
-		sigs.WriteString(" ")
-		sigs.WriteString(b64)
-		sigs.WriteString("\n")
-
-		// Also create a new note.Signature and pop it into the note's Sigs list (this will cause
-		// the signature to be present in the output when we call note.Sign below.
-		n.Sigs = append(n.Sigs, note.Signature{Name: name, Hash: hash, Base64: b64})
-	}
-	// Serialise the full signed note by calling Sign.
-	// Note that we're not passing any signers here because we've already added signatures in the loop above, so
-	// this call becomes just a serialisation function.
-	signed, err := note.Sign(n)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return signed, sigs.Bytes(), nil
-}
-
-// isValiSignerdName reports whether name is valid.
-// It must be non-empty and not have any Unicode spaces or pluses.
-func isValidSignerName(name string) bool {
-	return name != "" && utf8.ValidString(name) && strings.IndexFunc(name, unicode.IsSpace) < 0 && !strings.Contains(name, "+")
-}
-
-type signSubtreeFunc func(context.Context, uint64, uint64, []byte, [][]byte, []byte) ([]byte, error)
-
-// subtreeWitness returns a function which implements the witness sign-subtree operation for the configured log.
-//
-// The returned function will only sign subtrees where the provided checkpoint has already been signed by the mirror.
-func subtreeWitness(ctx context.Context, opts *MirrorOptions) (signSubtreeFunc, error) {
-	// Instantiate a witness for the configured log, but we'll only use its SignSubtree method.
-	// SignSubtree doesn't persist any state since everything required is provided by the request.
+// subtreeWitness returns a witness for underpinning the Mirror signing operations.
+func subtreeWitness(ctx context.Context, lr LogReader, mw MirrorWriter, opts *MirrorOptions) (*witness.Witness, error) {
 	subW, err := witness.New(ctx, witness.Opts{
-		// Use in-memory persistence as we don't need to persist any state for the SignSubtree operation.
-		Persistence: inmemory.New(),
-		Signers:     []note.Signer{opts.signer},
+		Persistence: &witnessPersistenceAdaptor{
+			origin: opts.origin,
+			lr:     lr,
+			mw:     mw,
+		},
+		Signers: []note.Signer{opts.signer},
 		VerifierForLog: func(_ context.Context, origin string) (note.Verifier, bool, error) {
 			// Only accept the log we're configured to mirror.
 			if origin != opts.origin {
@@ -595,5 +533,33 @@ func subtreeWitness(ctx context.Context, opts *MirrorOptions) (signSubtreeFunc, 
 		return nil, fmt.Errorf("witness.New: %v", err)
 	}
 
-	return subW.SignSubtree, nil
+	return subW, nil
+}
+
+// witnessPersistenceAdaptor adapts the Mirror's LogReader and MirrorWriter to satisfy
+// the requirements of the witness.Persistence interface.
+type witnessPersistenceAdaptor struct {
+	origin string
+	lr     LogReader
+	mw     MirrorWriter
+}
+
+func (p *witnessPersistenceAdaptor) Init(ctx context.Context) error {
+	return nil
+}
+
+func (p *witnessPersistenceAdaptor) Latest(ctx context.Context, origin string) ([]byte, error) {
+	if origin != p.origin {
+		return nil, witness.ErrUnknownLog
+	}
+
+	return p.lr.ReadCheckpoint(ctx)
+}
+
+func (p *witnessPersistenceAdaptor) Update(ctx context.Context, origin string, f func([]byte) ([]byte, error)) error {
+	if origin != p.origin {
+		return witness.ErrUnknownLog
+	}
+
+	return p.mw.UpdateCheckpoint(ctx, f)
 }

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -267,10 +267,7 @@ func TestMirrorTarget_AddEntries_CompleteUpload(t *testing.T) {
 
 	ctx := context.Background()
 	var gotUpdatedCP []byte
-	mt := &MirrorTarget{
-		origin:      testPendingCPOrigin,
-		logVerifier: testLogVerifier,
-		signer:      testMirrorSigner,
+	drv := &fakeDriver{
 		writer: &fakeMirrorWriter{
 			integrateFunc: func(ctx context.Context, fromBundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
 				if fromBundleIdx != testUploadStart/layout.EntryBundleWidth {
@@ -288,7 +285,17 @@ func TestMirrorTarget_AddEntries_CompleteUpload(t *testing.T) {
 		reader: &fakeLogReader{
 			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
 		},
-		cpSource: func(ctx context.Context) ([]byte, error) { return []byte(testPendingCP), nil },
+	}
+	mt, err := NewMirrorTarget(t.Context(), drv, &MirrorOptions{
+		origin:      testPendingCPOrigin,
+		logVerifier: testLogVerifier,
+		signer:      testMirrorSigner,
+		cpSource: func(ctx context.Context) ([]byte, error) {
+			return []byte(testPendingCP), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewMirrorTarget failed: %v", err)
 	}
 
 	validTicket, err := mt.seal([]byte(testPendingCP))
@@ -308,21 +315,19 @@ func TestMirrorTarget_AddEntries_CompleteUpload(t *testing.T) {
 		t.Errorf("got %d, want %d", got, want)
 	}
 	if len(cosigs) == 0 {
-		t.Errorf("got empty cosigs, want non-empty")
+		t.Fatalf("got empty cosigs, want non-empty")
 	}
 	if wantCP := append([]byte(testPendingCP), cosigs...); !bytes.Equal(gotUpdatedCP, wantCP) {
-		t.Errorf("got updated CP %x, want %x", gotUpdatedCP, wantCP)
+		t.Errorf("got updated CP %s, want %s", gotUpdatedCP, wantCP)
 	}
 }
 
 func TestMirrorTarget_AddEntries_ZeroCheckpoint(t *testing.T) {
 	testPendingCPZero := mustSignCP(testPendingCPOrigin, 0, testPendingCPRoot, testLogSigner)
-	ctx := context.Background()
+	ctx := t.Context()
 	var gotUpdatedCP []byte
-	mt := &MirrorTarget{
-		origin:      testPendingCPOrigin,
-		logVerifier: testLogVerifier,
-		signer:      testMirrorSigner,
+
+	drv := &fakeDriver{
 		writer: &fakeMirrorWriter{
 			integrateFunc: func(ctx context.Context, fromBundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
 				pendingCPRoot, err := base64.StdEncoding.DecodeString(testPendingCPRoot)
@@ -337,7 +342,17 @@ func TestMirrorTarget_AddEntries_ZeroCheckpoint(t *testing.T) {
 		reader: &fakeLogReader{
 			sizeFunc: func(ctx context.Context) (uint64, error) { return 0, nil },
 		},
-		cpSource: func(ctx context.Context) ([]byte, error) { return []byte(testPendingCPZero), nil },
+	}
+	mt, err := NewMirrorTarget(t.Context(), drv, &MirrorOptions{
+		origin:      testPendingCPOrigin,
+		logVerifier: testLogVerifier,
+		signer:      testMirrorSigner,
+		cpSource: func(ctx context.Context) ([]byte, error) {
+			return []byte(testPendingCPZero), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewMirrorTarget failed: %v", err)
 	}
 
 	// 1. First call with no ticket and uploadStart=0, uploadEnd=0.
@@ -436,17 +451,14 @@ func TestMirrorTarget_AddEntries_VerifySubtreeProof(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 
 			var verifyCalled bool
 			var gotStart, gotEnd, gotSize uint64
 			var gotProof [][]byte
 			var gotRoot []byte
 
-			mt := &MirrorTarget{
-				origin:      testPendingCPOrigin,
-				logVerifier: testLogVerifier,
-				signer:      testMirrorSigner,
+			drv := &fakeDriver{
 				writer: &fakeMirrorWriter{
 					integrateFunc: func(ctx context.Context, from uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
 						for _, err := range bundles {
@@ -461,16 +473,25 @@ func TestMirrorTarget_AddEntries_VerifySubtreeProof(t *testing.T) {
 				reader: &fakeLogReader{
 					sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
 				},
-				cpSource: func(ctx context.Context) ([]byte, error) { return []byte(testPendingCP), nil },
-				verifySubtreeProof: func(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot, root []byte) error {
-					verifyCalled = true
-					gotStart = start
-					gotEnd = end
-					gotSize = size
-					gotProof = proof
-					gotRoot = root
-					return tc.verifyErr
-				},
+			}
+			mt, err := NewMirrorTarget(ctx, drv, &MirrorOptions{
+				origin:      testPendingCPOrigin,
+				logVerifier: testLogVerifier,
+				signer:      testMirrorSigner,
+				cpSource:    func(ctx context.Context) ([]byte, error) { return []byte(testPendingCP), nil },
+			})
+			if err != nil {
+				t.Fatalf("NewMirrorTarget() failed: %v", err)
+			}
+
+			mt.verifySubtreeProof = func(hasher merkle.LogHasher, start, end, size uint64, proof [][]byte, subRoot, root []byte) error {
+				verifyCalled = true
+				gotStart = start
+				gotEnd = end
+				gotSize = size
+				gotProof = proof
+				gotRoot = root
+				return tc.verifyErr
 			}
 
 			validTicket, err := mt.seal([]byte(testPendingCP))
@@ -534,10 +555,7 @@ func TestMirrorTarget_AddEntries_Unaligned_PadsFirstBundle(t *testing.T) {
 	padEntries := testUploadStart % layout.EntryBundleWidth
 	padBundleRaw := make([]byte, 2*padEntries)
 
-	mt := &MirrorTarget{
-		origin:      testPendingCPOrigin,
-		logVerifier: testLogVerifier,
-		signer:      testMirrorSigner,
+	drv := &fakeDriver{
 		writer: &fakeMirrorWriter{
 			integrateFunc: func(ctx context.Context, fromBundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
 				if want := testUploadStart / layout.EntryBundleWidth; fromBundleIdx != want {
@@ -572,7 +590,16 @@ func TestMirrorTarget_AddEntries_Unaligned_PadsFirstBundle(t *testing.T) {
 				return padBundleRaw, nil
 			},
 		},
-		cpSource: func(ctx context.Context) ([]byte, error) { return []byte(testPendingCP), nil },
+	}
+
+	mt, err := NewMirrorTarget(t.Context(), drv, &MirrorOptions{
+		origin:      testPendingCPOrigin,
+		logVerifier: testLogVerifier,
+		signer:      testMirrorSigner,
+		cpSource:    func(ctx context.Context) ([]byte, error) { return []byte(testPendingCP), nil },
+	})
+	if err != nil {
+		t.Fatalf("NewMirrorTarget() failed: %v", err)
 	}
 
 	validTicket, err := mt.seal([]byte(testPendingCP))
@@ -597,22 +624,27 @@ func TestMirrorTarget_AddEntries_NoPendingCheckpoint(t *testing.T) {
 	)
 	ctx := t.Context()
 
-	mt := &MirrorTarget{
-		origin:      testPendingCPOrigin,
-		logVerifier: testLogVerifier,
-		signer:      testMirrorSigner,
+	drv := &fakeDriver{
 		writer: &fakeMirrorWriter{
 			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
 		},
 		reader: &fakeLogReader{
 			sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
 		},
+	}
+	mt, err := NewMirrorTarget(ctx, drv, &MirrorOptions{
+		origin:      testPendingCPOrigin,
+		logVerifier: testLogVerifier,
+		signer:      testMirrorSigner,
 		cpSource: func(ctx context.Context) ([]byte, error) {
 			return nil, nil // No pending checkpoint
 		},
+	})
+	if err != nil {
+		t.Fatalf("NewMirrorTarget() failed: %v", err)
 	}
 
-	_, _, _, _, err := mt.AddEntries(ctx, testIntegratedSize, testIntegratedSize+10, nil, func() (*MirrorPackage, error) {
+	_, _, _, _, err = mt.AddEntries(ctx, testIntegratedSize, testIntegratedSize+10, nil, func() (*MirrorPackage, error) {
 		return nil, io.EOF
 	})
 	if !errors.Is(err, ErrNoPendingCheckpoint) {
@@ -656,10 +688,7 @@ func TestMirrorTarget_AddEntries_UploadStartConflicts(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mt := &MirrorTarget{
-				origin:      testPendingCPOrigin,
-				logVerifier: testLogVerifier,
-				signer:      testMirrorSigner,
+			drv := &fakeDriver{
 				writer: &fakeMirrorWriter{
 					integrateFunc: func(ctx context.Context, fromBundleIdx uint64, bundles iter.Seq2[*api.EntryBundle, error]) (uint64, []byte, error) {
 						for _, err := range bundles {
@@ -677,7 +706,15 @@ func TestMirrorTarget_AddEntries_UploadStartConflicts(t *testing.T) {
 				reader: &fakeLogReader{
 					sizeFunc: func(ctx context.Context) (uint64, error) { return testIntegratedSize, nil },
 				},
-				cpSource: func(ctx context.Context) ([]byte, error) { return []byte(testPendingCPCustom), nil },
+			}
+			mt, err := NewMirrorTarget(ctx, drv, &MirrorOptions{
+				origin:      testPendingCPOrigin,
+				logVerifier: testLogVerifier,
+				signer:      testMirrorSigner,
+				cpSource:    func(ctx context.Context) ([]byte, error) { return []byte(testPendingCPCustom), nil },
+			})
+			if err != nil {
+				t.Fatalf("NewMirrorTarget() failed: %v", err)
 			}
 
 			validTicket, err := mt.seal([]byte(testPendingCPCustom))
@@ -795,10 +832,21 @@ func TestMirrorTarget_CustomOrigin_AddEntries(t *testing.T) {
 	}
 }
 
-type fakeDriver struct{}
+type fakeDriver struct {
+	writer MirrorWriter
+	reader LogReader
+}
 
 func (f *fakeDriver) MirrorWriter(ctx context.Context, opts *MirrorOptions) (MirrorWriter, LogReader, error) {
-	return &fakeMirrorWriter{}, &fakeLogReader{}, nil
+	w := f.writer
+	if w == nil {
+		w = &fakeMirrorWriter{}
+	}
+	r := f.reader
+	if r == nil {
+		r = &fakeLogReader{}
+	}
+	return w, r, nil
 }
 
 func TestMirrorTarget_SignSubtree(t *testing.T) {

--- a/mirror_lifecycle_test.go
+++ b/mirror_lifecycle_test.go
@@ -1045,6 +1045,263 @@ func TestMirrorTarget_SubtreeWitness_NilSigner(t *testing.T) {
 	}
 }
 
+func buildTestTiles(t *testing.T) (cp256Raw []byte, cp512Raw []byte, root256 []byte, root512 []byte, fetcher func(ctx context.Context, level, index uint64, p uint8) ([]byte, error)) {
+	t.Helper()
+	hasher := rfc6962.DefaultHasher
+	crf := &compact.RangeFactory{Hash: hasher.HashChildren}
+
+	cr0 := crf.NewEmptyRange(0)
+	tile0Nodes := make([][]byte, 256)
+	for i := range 256 {
+		h := hasher.HashLeaf(fmt.Appendf(nil, "entry-%d", i))
+		tile0Nodes[i] = h
+		if err := cr0.Append(h, nil); err != nil {
+			t.Fatalf("cr0.Append: %v", err)
+		}
+	}
+	r0, err := cr0.GetRootHash(nil)
+	if err != nil {
+		t.Fatalf("cr0.GetRootHash: %v", err)
+	}
+
+	cr1 := crf.NewEmptyRange(0)
+	tile1Nodes := make([][]byte, 256)
+	for i := range 256 {
+		h := hasher.HashLeaf(fmt.Appendf(nil, "entry-%d", 256+i))
+		tile1Nodes[i] = h
+		if err := cr1.Append(h, nil); err != nil {
+			t.Fatalf("cr1.Append: %v", err)
+		}
+	}
+	r1, err := cr1.GetRootHash(nil)
+	if err != nil {
+		t.Fatalf("cr1.GetRootHash: %v", err)
+	}
+
+	r512 := hasher.HashChildren(r0, r1)
+
+	tile0Raw, err := (&api.HashTile{Nodes: tile0Nodes}).MarshalText()
+	if err != nil {
+		t.Fatalf("tile0.MarshalText: %v", err)
+	}
+	tile1Raw, err := (&api.HashTile{Nodes: tile1Nodes}).MarshalText()
+	if err != nil {
+		t.Fatalf("tile1.MarshalText: %v", err)
+	}
+	tileL1Raw, err := (&api.HashTile{Nodes: [][]byte{r0, r1}}).MarshalText()
+	if err != nil {
+		t.Fatalf("tileL1.MarshalText: %v", err)
+	}
+
+	cp256 := mustSignCP(testPendingCPOrigin, 256, base64.StdEncoding.EncodeToString(r0), testLogSigner)
+	cp512 := mustSignCP(testPendingCPOrigin, 512, base64.StdEncoding.EncodeToString(r512), testLogSigner)
+
+	fetcher = func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+		if level == 0 && index == 0 {
+			return tile0Raw, nil
+		}
+		if level == 0 && index == 1 {
+			return tile1Raw, nil
+		}
+		if level == 1 && index == 0 {
+			return tileL1Raw, nil
+		}
+		return nil, fmt.Errorf("tile not found: level %d, index %d, p %d", level, index, p)
+	}
+
+	return cp256, cp512, r0, r512, fetcher
+}
+
+func TestMirrorTarget_PublishCheckpoint_RetryStale(t *testing.T) {
+	ctx := t.Context()
+	_, cp512, root256, _, tileFetcher := buildTestTiles(t)
+
+	for _, test := range []struct {
+		desc           string
+		initialOldSize uint64
+		storedCP       []byte
+	}{
+		{
+			desc:           "oldSize 0 but storage has size 256 checkpoint",
+			initialOldSize: 0,
+			storedCP:       mustCosignCP(t, testPendingCPOrigin, 256, root256, testLogSigner, testMirrorSigner),
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			currentPublishedCP := test.storedCP
+
+			drv := &fakeDriver{
+				writer: &fakeMirrorWriter{
+					updateCheckpointFunc: func(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error {
+						newCP, err := f(currentPublishedCP)
+						if err != nil {
+							return err
+						}
+						currentPublishedCP = newCP
+						return nil
+					},
+				},
+				reader: &fakeLogReader{
+					readCheckpoint: func(ctx context.Context) ([]byte, error) {
+						return currentPublishedCP, nil
+					},
+					readTile: tileFetcher,
+				},
+			}
+
+			mt, err := NewMirrorTarget(ctx, drv, &MirrorOptions{
+				origin:      testPendingCPOrigin,
+				logVerifier: testLogVerifier,
+				signer:      testMirrorSigner,
+				cpSource: func(ctx context.Context) ([]byte, error) {
+					return cp512, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewMirrorTarget failed: %v", err)
+			}
+
+			mt.oldSize.Store(test.initialOldSize)
+
+			sigs, pubSize, err := mt.publishCheckpoint(ctx, cp512, 512)
+			if err != nil {
+				t.Fatalf("publishCheckpoint failed: %v", err)
+			}
+			if pubSize != 512 {
+				t.Errorf("pubSize = %d, want 512", pubSize)
+			}
+			if len(sigs) == 0 {
+				t.Errorf("got empty signatures, want cosignature")
+			}
+			if mt.oldSize.Load() != 512 {
+				t.Errorf("mt.oldSize = %d, want 512", mt.oldSize.Load())
+			}
+
+			if wantCP := append([]byte(cp512), sigs...); !bytes.Equal(currentPublishedCP, wantCP) {
+				t.Errorf("currentPublishedCP = %s, want %s", currentPublishedCP, wantCP)
+			}
+		})
+	}
+}
+
+func TestMirrorTarget_PublishCheckpoint_Errors(t *testing.T) {
+	ctx := t.Context()
+	cp256, cp512, root256, root512, tileFetcher := buildTestTiles(t)
+
+	errTileFetch := errors.New("tile fetch error")
+	errStorageWrite := errors.New("storage write error")
+
+	for _, test := range []struct {
+		desc           string
+		initialOldSize uint64
+		storedCP       []byte
+		newCP          []byte
+		newCPSize      uint64
+		readTile       func(ctx context.Context, level, index uint64, p uint8) ([]byte, error)
+		updateCP       func(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error
+		wantErr        error
+		wantErrSubstr  string
+	}{
+		{
+			desc:           "consistency proof fetch error",
+			initialOldSize: 256,
+			storedCP:       mustCosignCP(t, testPendingCPOrigin, 256, root256, testLogSigner, testMirrorSigner),
+			newCP:          cp512,
+			newCPSize:      512,
+			readTile: func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+				return nil, errTileFetch
+			},
+			wantErrSubstr: "failed to get consistency proof",
+		},
+		{
+			desc:           "invalid consistency proof from corrupt tile",
+			initialOldSize: 256,
+			storedCP:       mustCosignCP(t, testPendingCPOrigin, 256, root256, testLogSigner, testMirrorSigner),
+			newCP:          cp512,
+			newCPSize:      512,
+			readTile: func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
+				if level == 1 && index == 0 {
+					corruptTile := &api.HashTile{Nodes: [][]byte{root256, bytes.Repeat([]byte{0xff}, 32)}}
+					return corruptTile.MarshalText()
+				}
+				return tileFetcher(ctx, level, index, p)
+			},
+			wantErr: witness.ErrInvalidProof,
+		},
+		{
+			desc:           "storage UpdateCheckpoint error",
+			initialOldSize: 0,
+			storedCP:       nil,
+			newCP:          cp256,
+			newCPSize:      256,
+			readTile:       tileFetcher,
+			updateCP: func(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error {
+				return errStorageWrite
+			},
+			wantErr: errStorageWrite,
+		},
+		{
+			desc:           "tree size regression - newCP smaller than storage CP",
+			initialOldSize: 0,
+			storedCP:       mustCosignCP(t, testPendingCPOrigin, 512, root512, testLogSigner, testMirrorSigner),
+			newCP:          cp256,
+			newCPSize:      256,
+			readTile:       tileFetcher,
+			wantErrSubstr:  "failed to get consistency proof",
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			currentPublishedCP := test.storedCP
+
+			drv := &fakeDriver{
+				writer: &fakeMirrorWriter{
+					updateCheckpointFunc: func(ctx context.Context, f func(oldCP []byte) (newCP []byte, err error)) error {
+						if test.updateCP != nil {
+							return test.updateCP(ctx, f)
+						}
+						newCP, err := f(currentPublishedCP)
+						if err != nil {
+							return err
+						}
+						currentPublishedCP = newCP
+						return nil
+					},
+				},
+				reader: &fakeLogReader{
+					readCheckpoint: func(ctx context.Context) ([]byte, error) {
+						return currentPublishedCP, nil
+					},
+					readTile: test.readTile,
+				},
+			}
+
+			mt, err := NewMirrorTarget(ctx, drv, &MirrorOptions{
+				origin:      testPendingCPOrigin,
+				logVerifier: testLogVerifier,
+				signer:      testMirrorSigner,
+				cpSource: func(ctx context.Context) ([]byte, error) {
+					return test.newCP, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewMirrorTarget failed: %v", err)
+			}
+
+			mt.oldSize.Store(test.initialOldSize)
+
+			_, _, err = mt.publishCheckpoint(ctx, test.newCP, test.newCPSize)
+			if err == nil {
+				t.Fatalf("publishCheckpoint succeeded, want error")
+			}
+			if test.wantErr != nil && !errors.Is(err, test.wantErr) {
+				t.Errorf("publishCheckpoint error = %v, want error wrapping %v", err, test.wantErr)
+			}
+			if test.wantErrSubstr != "" && !strings.Contains(err.Error(), test.wantErrSubstr) {
+				t.Errorf("publishCheckpoint error = %v, want substring %q", err, test.wantErrSubstr)
+			}
+		})
+	}
+}
 // mustCosignCP is a helper to sign checkpoints with multiple signers.
 func mustCosignCP(t *testing.T, origin string, size uint64, root []byte, signers ...note.Signer) []byte {
 	t.Helper()


### PR DESCRIPTION
This PR builds upon the introduction of a mirror-witness in #1105 by fully delegating to it for _all_ mirror cosignatures.

Towards #945 