### PR TITLE
Enable "greedy" witnessing

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -797,7 +797,7 @@ func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogRea
 					defer cancel()
 
 					var err error
-					ws, err = witnessCheckpoint(ctx, witnessGateway.CosignCheckpoint, &o.witnesses, cp, cpSize, o.witnessOpts.FailOpen)
+					ws, err = witnessCheckpoint(ctx, witnessGateway.CosignCheckpoint, &o.witnesses, cp, cpSize, o.witnessOpts.FailOpen, o.witnessOpts.Greedy)
 					return err
 				})
 			}
@@ -808,7 +808,7 @@ func (o AppendOptions) CheckpointPublisherContext(ctx context.Context, lr LogRea
 					defer cancel()
 
 					var err error
-					ms, err = mirrorCheckpoint(ctx, mirrorGateway.CosignCheckpoint, &o.mirrors, cp, cpSize, o.mirrorOpts.FailOpen)
+					ms, err = mirrorCheckpoint(ctx, mirrorGateway.CosignCheckpoint, &o.mirrors, cp, cpSize, o.mirrorOpts.FailOpen, false)
 					return err
 				})
 			}
@@ -871,12 +871,12 @@ func (o AppendOptions) mirrorGateway(ctx context.Context, lr LogReader, httpClie
 
 // witnessCheckpoint takes care of witnessing the given checkpoint with the provided witness policy.
 // Returns signatures from witnesses, ready to append to the checkpoint, or an error.
-func witnessCheckpoint(ctx context.Context, cosign cosigSource, policy *WitnessGroup, cp []byte, cpSize uint64, failOpen bool) ([]byte, error) {
+func witnessCheckpoint(ctx context.Context, cosign cosigSource, policy *WitnessGroup, cp []byte, cpSize uint64, failOpen bool, greedy bool) ([]byte, error) {
 	return otel.Trace(ctx, "tessera.CheckpointPublisher.Witness", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
 		start := time.Now()
 		witAttr := []attribute.KeyValue{}
 
-		sigs, err := gatherCosignatures(ctx, "witness", cosign, policy, cp, cpSize, failOpen)
+		sigs, err := gatherCosignatures(ctx, "witness", cosign, policy, cp, cpSize, failOpen, greedy)
 		if err != nil {
 			if !errors.Is(err, errFailedOpen) {
 				appenderWitnessRequests.Add(ctx, 1, metric.WithAttributes(attribute.String("error.type", "failed")))
@@ -895,9 +895,9 @@ func witnessCheckpoint(ctx context.Context, cosign cosigSource, policy *WitnessG
 
 // mirrorCheckpoint takes care of mirroring the given checkpoint with the provided mirror policy.
 // Returns signatures from mirrors, ready to append to the checkpoint, or an error.
-func mirrorCheckpoint(ctx context.Context, cosign cosigSource, policy *WitnessGroup, cp []byte, cpSize uint64, failOpen bool) ([]byte, error) {
+func mirrorCheckpoint(ctx context.Context, cosign cosigSource, policy *WitnessGroup, cp []byte, cpSize uint64, failOpen bool, greedy bool) ([]byte, error) {
 	return otel.Trace(ctx, "tessera.CheckpointPublisher.Mirror", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
-		sigs, err := gatherCosignatures(ctx, "mirror", cosign, policy, cp, cpSize, failOpen)
+		sigs, err := gatherCosignatures(ctx, "mirror", cosign, policy, cp, cpSize, failOpen, greedy)
 		if err != nil {
 			if !errors.Is(err, errFailedOpen) {
 				slog.WarnContext(ctx, "Failed to collect mirror signatures", slog.Any("error", err))
@@ -917,7 +917,9 @@ var errFailedOpen = errors.New("failed-open")
 
 // gatherCosignatures gathers signatures from a source, applying a policy to determine if the signatures are sufficient.
 // It returns the first set of signatures which satisfy the policy, or an error if the policy is not met and failOpen is false.
-func gatherCosignatures(ctx context.Context, name string, fetcher cosigSource, policy *WitnessGroup, cp []byte, cpSize uint64, failOpen bool) ([]byte, error) {
+func gatherCosignatures(ctx context.Context, name string, fetcher cosigSource, policy *WitnessGroup, cp []byte, cpSize uint64, failOpen bool, greedy bool) ([]byte, error) {
+	maxExpectedResponses := len(policy.WitnessEndpoints())
+
 	// checkPolicy checks if the provided signatures satisfy the given policy.
 	checkPolicy := func(sigs []byte, failOpen bool) ([]byte, error) {
 		newCP := append(slices.Clone(cp), sigs...)
@@ -936,6 +938,7 @@ func gatherCosignatures(ctx context.Context, name string, fetcher cosigSource, p
 	// or the context is done.
 	collectSigs := func(ctx context.Context, sigCh <-chan []byte) ([]byte, error) {
 		var sigBlock bytes.Buffer
+		gotResponses := 0
 		for {
 			select {
 			case <-ctx.Done():
@@ -950,11 +953,16 @@ func gatherCosignatures(ctx context.Context, name string, fetcher cosigSource, p
 					if pErr != nil {
 						pErr = fmt.Errorf("%w: no more signatures available", pErr)
 					}
-					return sigs, pErr
+					if !greedy {
+						return sigs, pErr
+					}
 				}
+				gotResponses++
 				sigBlock.Write(sig)
 				// Don't allow failOpen here, or we'll break out of the collection loop prematurely.
-				if sigs, err := checkPolicy(sigBlock.Bytes(), false); err == nil {
+				sigs, err := checkPolicy(sigBlock.Bytes(), false)
+				// We can return with sigs early if either we've met policy (and we're not in greedy mode), or we've received a response from all configured witnesses.
+				if (err == nil && !greedy) || (gotResponses == maxExpectedResponses) {
 					return sigs, nil
 				}
 			}
@@ -1172,6 +1180,10 @@ type WitnessOptions struct {
 	// This setting is intended only for facilitating early "non-blocking" adoption of witnessing,
 	// and will be disabled and/or removed in the future.
 	FailOpen bool
+
+	// Greedy indicates that Tessera should attempt to collect as many cosignatures as possible within the time available.
+	// If unset, Tessera will stop waiting for more responses as soon as the policy has been met.
+	Greedy bool
 }
 
 // MirroringOptions contains extra optional configuration for how Tessera should use/interact with

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -949,20 +949,19 @@ func gatherCosignatures(ctx context.Context, name string, fetcher cosigSource, p
 				return sigs, pErr
 			case sig, ok := <-sigCh:
 				if !ok {
+					// No more signatures are coming.
 					sigs, pErr := checkPolicy(sigBlock.Bytes(), failOpen)
 					if pErr != nil {
 						pErr = fmt.Errorf("%w: no more signatures available", pErr)
 					}
-					if !greedy {
-						return sigs, pErr
-					}
+					return sigs, pErr
 				}
 				gotResponses++
 				sigBlock.Write(sig)
 				// Don't allow failOpen here, or we'll break out of the collection loop prematurely.
 				sigs, err := checkPolicy(sigBlock.Bytes(), false)
-				// We can return with sigs early if either we've met policy (and we're not in greedy mode), or we've received a response from all configured witnesses.
-				if (err == nil && !greedy) || (gotResponses == maxExpectedResponses) {
+				// We can return with sigs early if we've met policy and either we're not in greedy mode or we've received a response from all configured witnesses.
+				if err == nil && (!greedy || gotResponses == maxExpectedResponses) {
 					return sigs, nil
 				}
 			}

--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -916,7 +916,7 @@ type cosigSource func(ctx context.Context, cp []byte, cpSize uint64) <-chan []by
 var errFailedOpen = errors.New("failed-open")
 
 // gatherCosignatures gathers signatures from a source, applying a policy to determine if the signatures are sufficient.
-// It returns the first set of signatures which satisfy the policy, or an error if the policy is not met and failOpen is false.
+// It returns a set of signatures which satisfy the policy (potentially more than required if greedy is true), or an error if the policy is not met and failOpen is false.
 func gatherCosignatures(ctx context.Context, name string, fetcher cosigSource, policy *WitnessGroup, cp []byte, cpSize uint64, failOpen bool, greedy bool) ([]byte, error) {
 	maxExpectedResponses := len(policy.WitnessEndpoints())
 
@@ -958,11 +958,15 @@ func gatherCosignatures(ctx context.Context, name string, fetcher cosigSource, p
 				}
 				gotResponses++
 				sigBlock.Write(sig)
-				// Don't allow failOpen here, or we'll break out of the collection loop prematurely.
-				sigs, err := checkPolicy(sigBlock.Bytes(), false)
-				// We can return with sigs early if we've met policy and either we're not in greedy mode or we've received a response from all configured witnesses.
-				if err == nil && (!greedy || gotResponses == maxExpectedResponses) {
-					return sigs, nil
+				// If we're greedy, we need to keep collecting until we've got all the responses
+				// (or the context is cancelled).
+				// Otherwise we can return as soon as we've met the policy.
+				if !greedy || gotResponses == maxExpectedResponses {
+					// Don't allow failOpen here, or we'll break out of the collection loop prematurely.
+					sigs, err := checkPolicy(sigBlock.Bytes(), false)
+					if err == nil {
+						return sigs, nil
+					}
 				}
 			}
 		}

--- a/append_lifecycle_test.go
+++ b/append_lifecycle_test.go
@@ -893,12 +893,12 @@ func newMirrorHandler(t *testing.T, mirrorSKey string) http.HandlerFunc {
 		}
 	}
 }
-func mustNewWitness(t *testing.T, skey, urlStr string) Witness {
+func mustNewWitness(t *testing.T, vkey, urlStr string) Witness {
 	url, err := url.Parse(urlStr)
 	if err != nil {
 		t.Fatalf("Failed to parse URL %s: %v", urlStr, err)
 	}
-	wit, err := NewWitness(skey, url)
+	wit, err := NewWitness(vkey, url)
 	if err != nil {
 		t.Fatalf("failed to create witness: %v", err)
 	}

--- a/append_lifecycle_test.go
+++ b/append_lifecycle_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -289,13 +290,264 @@ func TestWithMirrors(t *testing.T) {
 	}
 }
 
+func TestWithWitnesses(t *testing.T) {
+	wit := mustNewWitness(t, testWit1VKey, "https://witness.example.com")
+	witnesses := NewWitnessGroup(1, wit)
+
+	for _, test := range []struct {
+		desc           string
+		witnessOpts    *WitnessOptions
+		expectTimeout  time.Duration
+		expectFailOpen bool
+		expectGreedy   bool
+	}{
+		{
+			desc:           "nil options",
+			witnessOpts:    nil,
+			expectTimeout:  DefaultWitnessTimeout,
+			expectFailOpen: false,
+			expectGreedy:   false,
+		},
+		{
+			desc: "custom options",
+			witnessOpts: &WitnessOptions{
+				Timeout:  5 * time.Second,
+				FailOpen: true,
+				Greedy:   true,
+			},
+			expectTimeout:  5 * time.Second,
+			expectFailOpen: true,
+			expectGreedy:   true,
+		},
+		{
+			desc: "zero timeout uses default",
+			witnessOpts: &WitnessOptions{
+				Timeout:  0,
+				FailOpen: true,
+				Greedy:   true,
+			},
+			expectTimeout:  DefaultWitnessTimeout,
+			expectFailOpen: true,
+			expectGreedy:   true,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			opts := NewAppendOptions().WithWitnesses(witnesses, test.witnessOpts)
+			if len(opts.witnesses.Components) != 1 {
+				t.Errorf("expected 1 witness component, got %d", len(opts.witnesses.Components))
+			}
+			if got, want := opts.witnessOpts.Timeout, test.expectTimeout; got != want {
+				t.Errorf("expected timeout %v, got %v", want, got)
+			}
+			if got, want := opts.witnessOpts.FailOpen, test.expectFailOpen; got != want {
+				t.Errorf("expected FailOpen %t, got %t", want, got)
+			}
+			if got, want := opts.witnessOpts.Greedy, test.expectGreedy; got != want {
+				t.Errorf("expected Greedy %t, got %t", want, got)
+			}
+		})
+	}
+}
+
 const (
 	testWit1VKey = "Wit1+55ee4561+AVhZSmQj9+SoL+p/nN0Hh76xXmF7QcHfytUrI1XfSClk"
 	testWit1SKey = "PRIVATE+KEY+Wit1+55ee4561+AeadRiG7XM4XiieCHzD8lxysXMwcViy5nYsoXURWGrlE"
+	testWit2VKey = "Wit2+85ecc407+AWVbwFJte9wMQIPSnEnj4KibeO6vSIOEDUTDp3o63c2x"
+	testWit2SKey = "PRIVATE+KEY+Wit2+85ecc407+AfPTvxw5eUcqSgivo2vaiC7JPOMUZ/9baHPSDrWqgdGm"
+	testWit3VKey = "Wit3+d3ed3be7+ASb6Uz1+fxAcXkMvDd7nGa3FjDce7LxIKmbbTCT0MpVn"
+	testWit3SKey = "PRIVATE+KEY+Wit3+d3ed3be7+AR2Kg8k6ccBr5QXz5SHtnkOS4UGQGEQaWi6Gfr6Mm3X5"
 
 	testMirrorVKey = "Mirror1+66ee4561+AVhZSmQj9+SoL+p/nN0Hh76xXmF7QcHfytUrI1XfSClk"
 	testMirrorSKey = "PRIVATE+KEY+Mirror1+66ee4561+AeadRiG7XM4XiieCHzD8lxysXMwcViy5nYsoXURWGrlE"
 )
+
+func createCosignature(t *testing.T, baseNote *note.Note, witnessSKey string) []byte {
+	t.Helper()
+	witnessSigner, err := f_note.NewSignerForCosignatureV1(witnessSKey)
+	if err != nil {
+		t.Fatalf("failed to create witness signer: %v", err)
+	}
+	signedNote, err := note.Sign(baseNote, witnessSigner)
+	if err != nil {
+		t.Fatalf("failed to sign note: %v", err)
+	}
+	idx := strings.Index(string(signedNote), "\n— "+witnessSigner.Name()+" ")
+	if idx < 0 {
+		t.Fatalf("signature line not found in signed note")
+	}
+	return []byte(string(signedNote)[idx+1:])
+}
+
+func TestGatherCosignatures(t *testing.T) {
+	logSigner := mustCreateSigner(t, testSignerKey)
+	logVerifier, err := note.NewVerifier("example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx")
+	if err != nil {
+		t.Fatalf("failed to create log verifier: %v", err)
+	}
+
+	wit1 := mustNewWitness(t, testWit1VKey, "https://wit1.example.com")
+	wit2 := mustNewWitness(t, testWit2VKey, "https://wit2.example.com")
+	wit3 := mustNewWitness(t, testWit3VKey, "https://wit3.example.com")
+	wit1Verifier, _ := f_note.NewVerifierForCosignatureV1(testWit1VKey)
+	wit2Verifier, _ := f_note.NewVerifierForCosignatureV1(testWit2VKey)
+	wit3Verifier, _ := f_note.NewVerifierForCosignatureV1(testWit3VKey)
+
+	n := &note.Note{
+		Text: "example.com/log/testdata\n5\nqINS1GRFhWHwdkUeqLEoP4yEMkTBBzxBkGwGQlVlVcs=\n",
+	}
+	signedCP, err := note.Sign(n, logSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sig1 := createCosignature(t, n, testWit1SKey)
+	sig2 := createCosignature(t, n, testWit2SKey)
+	sig3 := createCosignature(t, n, testWit3SKey)
+
+	for _, test := range []struct {
+		desc               string
+		policy             WitnessGroup
+		fetcher            func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte
+		timeout            time.Duration
+		failOpen           bool
+		greedy             bool
+		expectCosignatures []note.Verifier
+		expectErr          bool
+		expectFailedOpen   bool
+	}{
+		{
+			desc:   "empty policy",
+			policy: WitnessGroup{},
+			fetcher: func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+				ch := make(chan []byte)
+				close(ch)
+				return ch
+			},
+		},
+		{
+			desc:   "non-greedy stops after quorum is satisfied (1 of 2)",
+			policy: NewWitnessGroup(1, wit1, wit2),
+			fetcher: func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+				ch := make(chan []byte, 2)
+				ch <- sig1
+				ch <- sig2
+				return ch
+			},
+			greedy:             false,
+			expectCosignatures: []note.Verifier{wit1Verifier},
+		},
+		{
+			desc:   "greedy gathers surplus signatures (2 of 3 required, 3 provided)",
+			policy: NewWitnessGroup(2, wit1, wit2, wit3),
+			fetcher: func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+				ch := make(chan []byte, 3)
+				ch <- sig1
+				ch <- sig2
+				ch <- sig3
+				return ch
+			},
+			greedy:             true,
+			expectCosignatures: []note.Verifier{wit1Verifier, wit2Verifier, wit3Verifier},
+		},
+		{
+			desc:   "greedy succeeds when quorum is met and channel closes without further signatures (1 of 2 required, 1 provided)",
+			policy: NewWitnessGroup(1, wit1, wit2),
+			fetcher: func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+				ch := make(chan []byte, 1)
+				ch <- sig1
+				close(ch)
+				return ch
+			},
+			greedy:             true,
+			expectCosignatures: []note.Verifier{wit1Verifier},
+		},
+		{
+			desc:   "greedy fails when quorum is not met and channel closes (failOpen=false)",
+			policy: NewWitnessGroup(2, wit1, wit2),
+			fetcher: func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+				ch := make(chan []byte, 1)
+				ch <- sig1
+				close(ch)
+				return ch
+			},
+			greedy:    true,
+			failOpen:  false,
+			expectErr: true,
+		},
+		{
+			desc:   "greedy fails open when quorum is not met and channel closes (failOpen=true)",
+			policy: NewWitnessGroup(2, wit1, wit2),
+			fetcher: func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+				ch := make(chan []byte, 1)
+				ch <- sig1
+				close(ch)
+				return ch
+			},
+			greedy:             true,
+			failOpen:           true,
+			expectFailedOpen:   true,
+			expectCosignatures: []note.Verifier{wit1Verifier},
+		},
+		{
+			desc:   "greedy fails when quorum is not met on timeout (failOpen=false)",
+			policy: NewWitnessGroup(2, wit1, wit2),
+			fetcher: func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+				ch := make(chan []byte, 1)
+				ch <- sig1
+				return ch
+			},
+			timeout:   50 * time.Millisecond,
+			greedy:    true,
+			failOpen:  false,
+			expectErr: true,
+		},
+		{
+			desc:   "greedy fails open when quorum is not met on timeout (failOpen=true)",
+			policy: NewWitnessGroup(2, wit1, wit2),
+			fetcher: func(ctx context.Context, cp []byte, cpSize uint64) <-chan []byte {
+				ch := make(chan []byte, 1)
+				ch <- sig1
+				return ch
+			},
+			timeout:            50 * time.Millisecond,
+			greedy:             true,
+			failOpen:           true,
+			expectFailedOpen:   true,
+			expectCosignatures: []note.Verifier{wit1Verifier},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx := t.Context()
+			if test.timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, test.timeout)
+				defer cancel()
+			}
+			sigs, err := gatherCosignatures(ctx, "witness", test.fetcher, &test.policy, signedCP, 5, test.failOpen, test.greedy)
+			switch {
+			case test.expectFailedOpen:
+				if !errors.Is(err, errFailedOpen) {
+					t.Fatalf("expected errFailedOpen but got %v", err)
+				}
+			case test.expectErr:
+				if err == nil || errors.Is(err, errFailedOpen) {
+					t.Fatalf("expected error but got %v", err)
+				}
+			case err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			}
+			fullCP := append(slices.Clone(signedCP), sigs...)
+			verifiers := append([]note.Verifier{logVerifier}, test.expectCosignatures...)
+			parsedNote, err := note.Open(fullCP, note.VerifierList(verifiers...))
+			if err != nil {
+				t.Fatalf("failed to open note: %v", err)
+			}
+			if len(parsedNote.Sigs) != len(verifiers) {
+				t.Errorf("expected %d signatures, got %d", len(verifiers), len(parsedNote.Sigs))
+			}
+		})
+	}
+}
 
 func newWitnessHandler(t *testing.T, logVerifier note.Verifier, witnessSKey string) http.HandlerFunc {
 	witnessSigner, err := f_note.NewSignerForCosignatureV1(witnessSKey)
@@ -338,23 +590,42 @@ func TestCheckpointPublisher(t *testing.T) {
 		t.Fatalf("failed to create log verifier: %v", err)
 	}
 
-	witnessServer := httptest.NewServer(newWitnessHandler(t, logVerifier, testWit1SKey))
-	t.Cleanup(witnessServer.Close)
+	witnessServer1 := httptest.NewServer(newWitnessHandler(t, logVerifier, testWit1SKey))
+	t.Cleanup(witnessServer1.Close)
 
-	witnessServerURL, err := url.Parse(witnessServer.URL)
+	witnessServerURL1, err := url.Parse(witnessServer1.URL)
 	if err != nil {
-		t.Fatalf("failed to parse witness server url: %v", err)
+		t.Fatalf("failed to parse witness server 1 url: %v", err)
 	}
 
-	wit, err := NewWitness(testWit1VKey, witnessServerURL)
+	wit1, err := NewWitness(testWit1VKey, witnessServerURL1)
 	if err != nil {
-		t.Fatalf("failed to create witness: %v", err)
+		t.Fatalf("failed to create witness 1: %v", err)
 	}
-	witnesses := NewWitnessGroup(1, wit)
-	witVerifier, err := f_note.NewVerifierForCosignatureV1(testWit1VKey)
+	witnesses := NewWitnessGroup(1, wit1)
+	wit1Verifier, err := f_note.NewVerifierForCosignatureV1(testWit1VKey)
 	if err != nil {
-		t.Fatalf("failed to create witness verifier: %v", err)
+		t.Fatalf("failed to create witness 1 verifier: %v", err)
 	}
+
+	witnessServer2 := httptest.NewServer(newWitnessHandler(t, logVerifier, testWit2SKey))
+	t.Cleanup(witnessServer2.Close)
+
+	witnessServerURL2, err := url.Parse(witnessServer2.URL)
+	if err != nil {
+		t.Fatalf("failed to parse witness server 2 url: %v", err)
+	}
+
+	wit2, err := NewWitness(testWit2VKey, witnessServerURL2)
+	if err != nil {
+		t.Fatalf("failed to create witness 2: %v", err)
+	}
+	wit2Verifier, err := f_note.NewVerifierForCosignatureV1(testWit2VKey)
+	if err != nil {
+		t.Fatalf("failed to create witness 2 verifier: %v", err)
+	}
+
+	multiWitnesses := NewWitnessGroup(1, wit1, wit2)
 
 	mirrorServer := httptest.NewServer(newMirrorHandler(t, testMirrorSKey))
 	t.Cleanup(mirrorServer.Close)
@@ -375,11 +646,13 @@ func TestCheckpointPublisher(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		desc               string
-		opts               *AppendOptions
-		witnessFails       bool
-		expectCosignatures []note.Verifier
-		expectErr          bool
+		desc                  string
+		opts                  *AppendOptions
+		witnessFails          bool
+		partialWitnessFails   bool
+		expectCosignatures    []note.Verifier
+		expectNumCosignatures int
+		expectErr             bool
 	}{
 		{
 			desc: "no witnesses, no mirrors",
@@ -388,7 +661,7 @@ func TestCheckpointPublisher(t *testing.T) {
 		{
 			desc:               "witnesses only",
 			opts:               NewAppendOptions().WithCheckpointSigner(logSigner).WithWitnesses(witnesses, &WitnessOptions{Timeout: time.Second}),
-			expectCosignatures: []note.Verifier{witVerifier},
+			expectCosignatures: []note.Verifier{wit1Verifier},
 		},
 		{
 			desc:               "mirrors only",
@@ -398,7 +671,7 @@ func TestCheckpointPublisher(t *testing.T) {
 		{
 			desc:               "witnesses and mirrors",
 			opts:               NewAppendOptions().WithCheckpointSigner(logSigner).WithWitnesses(witnesses, &WitnessOptions{Timeout: time.Second}).WithMirrors(mirrors, &MirroringOptions{Timeout: time.Second}),
-			expectCosignatures: []note.Verifier{witVerifier, mirrorVerifier},
+			expectCosignatures: []note.Verifier{wit1Verifier, mirrorVerifier},
 		},
 		{
 			desc:         "witness fails, failOpen=false",
@@ -410,6 +683,22 @@ func TestCheckpointPublisher(t *testing.T) {
 			desc:         "witness fails, failOpen=true",
 			opts:         NewAppendOptions().WithCheckpointSigner(logSigner).WithWitnesses(witnesses, &WitnessOptions{FailOpen: true, Timeout: time.Second}),
 			witnessFails: true,
+		},
+		{
+			desc:                  "multi witnesses greedy=false",
+			opts:                  NewAppendOptions().WithCheckpointSigner(logSigner).WithWitnesses(multiWitnesses, &WitnessOptions{Timeout: time.Second, Greedy: false}),
+			expectNumCosignatures: 1,
+		},
+		{
+			desc:               "multi witnesses greedy=true",
+			opts:               NewAppendOptions().WithCheckpointSigner(logSigner).WithWitnesses(multiWitnesses, &WitnessOptions{Timeout: time.Second, Greedy: true}),
+			expectCosignatures: []note.Verifier{wit1Verifier, wit2Verifier},
+		},
+		{
+			desc:                "multi witnesses greedy=true with one failing witness",
+			opts:                NewAppendOptions().WithCheckpointSigner(logSigner).WithWitnesses(multiWitnesses, &WitnessOptions{Timeout: time.Second, Greedy: true}),
+			partialWitnessFails: true,
+			expectCosignatures:  []note.Verifier{wit1Verifier},
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
@@ -427,6 +716,18 @@ func TestCheckpointPublisher(t *testing.T) {
 				// Re-configure option to use failing witnesses
 				test.opts.WithWitnesses(failingWitnesses, &test.opts.witnessOpts)
 			}
+			if test.partialWitnessFails {
+				failingWitnessServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "internal error", http.StatusInternalServerError)
+				}))
+				defer failingWitnessServer.Close()
+
+				failingURL, _ := url.Parse(failingWitnessServer.URL)
+				failingWit, _ := NewWitness(testWit2VKey, failingURL)
+				partiallyFailingWitnesses := NewWitnessGroup(1, wit1, failingWit)
+
+				test.opts.WithWitnesses(partiallyFailingWitnesses, &test.opts.witnessOpts)
+			}
 
 			lr := newFakeLogReaderForTest(t)
 
@@ -443,17 +744,28 @@ func TestCheckpointPublisher(t *testing.T) {
 			}
 
 			// Open checkpoint to verify signatures
-			wantV := append([]note.Verifier{logVerifier}, test.expectCosignatures...)
-			n, err := note.Open(cp, note.VerifierList(wantV...))
-			if err != nil {
-				t.Fatalf("failed to open signed checkpoint: %v", err)
-			}
+			if test.expectNumCosignatures > 0 {
+				allV := []note.Verifier{logVerifier, wit1Verifier, wit2Verifier, mirrorVerifier}
+				n, err := note.Open(cp, note.VerifierList(allV...))
+				if err != nil {
+					t.Fatalf("failed to open signed checkpoint: %v", err)
+				}
+				if got, want := len(n.Sigs), 1+test.expectNumCosignatures; got != want {
+					t.Errorf("expected %d signatures, got %d", want, got)
+				}
+			} else {
+				wantV := append([]note.Verifier{logVerifier}, test.expectCosignatures...)
+				n, err := note.Open(cp, note.VerifierList(wantV...))
+				if err != nil {
+					t.Fatalf("failed to open signed checkpoint: %v", err)
+				}
 
-			// Check that all required verifiers signed it
-			if len(n.Sigs) != len(wantV) {
-				t.Logf("cp = %q", string(cp))
-				t.Logf("n.Sigs = %+v", n.Sigs)
-				t.Errorf("expected %d signatures, got %d", len(wantV), len(n.Sigs))
+				// Check that all required verifiers signed it
+				if len(n.Sigs) != len(wantV) {
+					t.Logf("cp = %q", string(cp))
+					t.Logf("n.Sigs = %+v", n.Sigs)
+					t.Errorf("expected %d signatures, got %d", len(wantV), len(n.Sigs))
+				}
 			}
 		})
 	}
@@ -580,4 +892,15 @@ func newMirrorHandler(t *testing.T, mirrorSKey string) http.HandlerFunc {
 			return
 		}
 	}
+}
+func mustNewWitness(t *testing.T, skey, urlStr string) Witness {
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		t.Fatalf("Failed to parse URL %s: %v", urlStr, err)
+	}
+	wit, err := NewWitness(skey, url)
+	if err != nil {
+		t.Fatalf("failed to create witness: %v", err)
+	}
+	return wit
 }


### PR DESCRIPTION
This PR allows logs to configure witnessing to include any "surplus" cosignatures (i.e. beyond the strict set needed to satisfy the witness quorum policy) which can be fetched within the timeout.

Resolves #866 