### PR TITLE
[MTC] Define MTCProof structure

### DIFF
--- a/cmd/mtc/log/internal/handler/handlers_test.go
+++ b/cmd/mtc/log/internal/handler/handlers_test.go
@@ -137,7 +137,7 @@ func TestAddTBSHandler(t *testing.T) {
 			name:       "success",
 			body:       func() io.Reader { return bytes.NewReader(validJSON) },
 			wantStatus: http.StatusCreated,
-			wantBody:   `{"index":0,"mtcProof":{}}`,
+			wantBody:   `{"index":0,"mtcProof":null}`,
 		},
 		{
 			name:       "malformed json",

--- a/cmd/mtc/log/internal/mtcproof/mtcproof.go
+++ b/cmd/mtc/log/internal/mtcproof/mtcproof.go
@@ -1,0 +1,249 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtcproof
+
+import (
+	"bytes"
+	"cmp"
+	"crypto/sha256"
+	"crypto/x509"
+	"fmt"
+	"slices"
+	"strings"
+
+	"golang.org/x/crypto/cryptobyte"
+)
+
+const (
+	oidPrefix           = "oid/1.3.6.1.4.1."
+	penPrefixDERLen     = 5
+	maxTrustAnchorIDLen = (1 << 8) - 1
+	maxUint48           = (1 << 48) - 1
+)
+
+// hashValue represents a 32-byte hash as per
+// draft-ietf-plants-merkle-tree-certs section 6.2.
+type hashValue [sha256.Size]byte
+
+// SubtreeSignature represents a cosigner's signature on a subtree root
+// as per draft-ietf-plants-merkle-tree-certs section 6.2:
+type SubtreeSignature struct {
+	// CosignerID is the binary representation of the trust anchor ID (1..255 bytes).
+	CosignerID []byte
+	// Signature is the raw signature bytes over the subtree.
+	Signature []byte
+}
+
+// mtcProof represents an MTC inclusion proof as per
+// draft-ietf-plants-merkle-tree-certs section 6.2.
+//
+// New instances MUST be created with new().
+type mtcProof struct {
+	extensions     []byte
+	start          uint64
+	end            uint64
+	inclusionProof []hashValue
+	signatures     []SubtreeSignature
+}
+
+// ParseCosignerID converts an ASCII cosigner name into its binary representation
+// as per draft-ietf-tls-trust-anchor-ids Section 3.
+func ParseCosignerID(name string) ([]byte, error) {
+	if !strings.HasPrefix(name, oidPrefix) {
+		return nil, fmt.Errorf("cosigner name %q must start with %q", name, oidPrefix)
+	}
+	oid, err := x509.ParseOID(strings.TrimPrefix(name, "oid/"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid cosigner ID OID %q: %w", name, err)
+	}
+	der, err := oid.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("marshal cosigner ID OID %q: %w", name, err)
+	}
+	// SPEC: draft-ietf-tls-trust-anchor-ids section 3.
+	// "For use in binary protocols such as TLS, a trust anchor ID's binary
+	// representation consists of the contents octets of the relative object
+	// identifier's DER encoding, as described in Section 8.20 of [X690]. Note
+	// this omits the tag and length portion of the encoding."
+	res := der[penPrefixDERLen:]
+	if l := len(res); l == 0 || l > maxTrustAnchorIDLen {
+		return nil, fmt.Errorf("cosigner ID binary length must be 1..%d bytes, got %d", maxTrustAnchorIDLen, l)
+	}
+	return res, nil
+}
+
+// New validates MTC proof parameters, orders signatures canonically, and returns
+// the TLS-encoded MTCProof binary bytes.
+func New(extensions []byte, start, end uint64, inclusionProof [][]byte, signatures []SubtreeSignature) ([]byte, error) {
+	p, err := new(extensions, start, end, inclusionProof, signatures)
+	if err != nil {
+		return nil, err
+	}
+	return p.marshal()
+}
+
+// new constructs a validated mtcProof with signatures sorted canonically.
+func new(extensions []byte, start, end uint64, inclusionProof [][]byte, signatures []SubtreeSignature) (*mtcProof, error) {
+	// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+	// "uint48 start; uint48 end;"
+	if start > maxUint48 {
+		return nil, fmt.Errorf("start index %d exceeds uint48 maximum (%d)", start, maxUint48)
+	}
+	if end > maxUint48 {
+		return nil, fmt.Errorf("end index %d exceeds uint48 maximum (%d)", end, maxUint48)
+	}
+	if start >= end {
+		return nil, fmt.Errorf("start (%d) must be strictly less than end (%d)", start, end)
+	}
+	// SPEC: draft-ietf-plants-merkle-tree-certs section 5.2.1.
+	// "opaque extension_data<0..2^16-1>; "
+	if l := len(extensions); l >= 1<<16 {
+		return nil, fmt.Errorf("extensions too large (%d bytes, max %d)", l, (1<<16)-1)
+	}
+	// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+	// "HashValue inclusion_proof<0..2^16-1>;"
+	if l := len(inclusionProof) * sha256.Size; l >= 1<<16 {
+		return nil, fmt.Errorf("inclusion proof too large (%d bytes, max %d)", l, (1<<16)-1)
+	}
+
+	hashes := make([]hashValue, len(inclusionProof))
+	for i, n := range inclusionProof {
+		if l := len(n); l != sha256.Size {
+			return nil, fmt.Errorf("inclusion proof node %d invalid size: got %d bytes, want %d", i, l, sha256.Size)
+		}
+		hashes[i] = hashValue(n)
+	}
+
+	// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+	// "Each element of the signatures field MUST have a unique cosigner_id.
+	// Elements MUST be ordered by cosigner_id"
+	sortedSigs := slices.Clone(signatures)
+	slices.SortFunc(sortedSigs, func(a, b SubtreeSignature) int {
+		return compareCosignerIDs(a.CosignerID, b.CosignerID)
+	})
+
+	var totalSigsLen int
+	for i, sig := range sortedSigs {
+		// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+		// /* From Section 4.1 of draft-ietf-tls-trust-anchor-ids */
+		// "opaque TrustAnchorID<1..2^8-1>;"
+		if l := len(sig.CosignerID); l == 0 || l > maxTrustAnchorIDLen {
+			return nil, fmt.Errorf("cosigner_id length must be 1..%d bytes, got %d", maxTrustAnchorIDLen, l)
+		}
+		// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+		// "opaque signature<0..2^16-1>;"
+		if l := len(sig.Signature); l >= 1<<16 {
+			return nil, fmt.Errorf("signature too large (%d bytes, max %d)", l, (1<<16)-1)
+		}
+		// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+		// "SubtreeSignature signatures<0..2^16-1>;"
+		// In TLS presentation syntax, each SubtreeSignature consists of:
+		// 1 byte (length of TrustAnchorID) + len(CosignerID) + 2 bytes (length of signature) + len(Signature).
+		totalSigsLen += 1 + len(sig.CosignerID) + 2 + len(sig.Signature)
+		if totalSigsLen >= 1<<16 {
+			return nil, fmt.Errorf("signatures vector too large (%d bytes, max %d)", totalSigsLen, (1<<16)-1)
+		}
+		// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+		// "An MTCProof parser MUST reject the input if there are duplicate cosigner_id values,
+		// or if they are not ordered correctly. This can be done by checking each cosigner_id
+		// value comes strictly after the previous one in the above order."
+		if i > 0 && compareCosignerIDs(sortedSigs[i-1].CosignerID, sig.CosignerID) == 0 {
+			return nil, fmt.Errorf("duplicate cosigner_id: %x", sig.CosignerID)
+		}
+	}
+
+	return &mtcProof{
+		extensions:     slices.Clone(extensions),
+		start:          start,
+		end:            end,
+		inclusionProof: hashes,
+		signatures:     sortedSigs,
+	}, nil
+}
+
+// marshal TLS encodes mtcProof.
+//
+// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+// /* From Section 4.1 of draft-ietf-tls-trust-anchor-ids */
+// opaque TrustAnchorID<1..2^8-1>;
+//
+// opaque HashValue[HASH_SIZE];
+//
+// struct {
+//     TrustAnchorID cosigner_id;
+//     opaque signature<0..2^16-1>;
+// } SubtreeSignature;
+//
+// struct {
+//     MTCLogEntryExtension extensions<0..2^16-1>;
+//     uint48 start;
+//     uint48 end;
+//     HashValue inclusion_proof<0..2^16-1>;
+//     SubtreeSignature signatures<0..2^16-1>;
+// } MTCProof;
+func (p *mtcProof) marshal() ([]byte, error) {
+	var b cryptobyte.Builder
+
+	// MTCLogEntryExtension extensions<0..2^16-1>
+	b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		child.AddBytes(p.extensions)
+	})
+
+	// uint48 start
+	addUint48(&b, p.start)
+
+	// uint48 end
+	addUint48(&b, p.end)
+
+	// HashValue inclusion_proof<0..2^16-1>
+	b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		for _, h := range p.inclusionProof {
+			child.AddBytes(h[:])
+		}
+	})
+
+	// SubtreeSignature signatures<0..2^16-1>
+	b.AddUint16LengthPrefixed(func(child *cryptobyte.Builder) {
+		for _, sig := range p.signatures {
+			// TrustAnchorID cosigner_id<1..2^8-1>
+			child.AddUint8LengthPrefixed(func(c *cryptobyte.Builder) {
+				c.AddBytes(sig.CosignerID)
+			})
+			// opaque signature<0..2^16-1>
+			child.AddUint16LengthPrefixed(func(s *cryptobyte.Builder) {
+				s.AddBytes(sig.Signature)
+			})
+		}
+	})
+
+	return b.Bytes()
+}
+
+// addUint48 appends a big-endian, 48-bit value to the byte string.
+func addUint48(b *cryptobyte.Builder, v uint64) {
+	buf := [6]byte{byte(v >> 40), byte(v >> 32), byte(v >> 24), byte(v >> 16), byte(v >> 8), byte(v)}
+	b.AddBytes(buf[:])
+}
+
+// compareCosignerIDs compares two cosigner_id byte slices.
+// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+// " - Shorter byte strings are ordered before longer byte strings.
+//   - Byte strings of the same length are ordered lexicographically."
+func compareCosignerIDs(a, b []byte) int {
+	if len(a) != len(b) {
+		return cmp.Compare(len(a), len(b))
+	}
+	return bytes.Compare(a, b)
+}

--- a/cmd/mtc/log/internal/mtcproof/mtcproof.go
+++ b/cmd/mtc/log/internal/mtcproof/mtcproof.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	oidPrefix           = "oid/1.3.6.1.4.1."
-	penPrefixDERLen     = 5
+	oidPrefixDERLen     = 5
 	maxTrustAnchorIDLen = (1 << 8) - 1
 	maxUint48           = (1 << 48) - 1
 )
@@ -77,16 +77,16 @@ func ParseCosignerID(name string) ([]byte, error) {
 	// representation consists of the contents octets of the relative object
 	// identifier's DER encoding, as described in Section 8.20 of [X690]. Note
 	// this omits the tag and length portion of the encoding."
-	res := der[penPrefixDERLen:]
+	res := der[oidPrefixDERLen:]
 	if l := len(res); l == 0 || l > maxTrustAnchorIDLen {
 		return nil, fmt.Errorf("cosigner ID binary length must be 1..%d bytes, got %d", maxTrustAnchorIDLen, l)
 	}
 	return res, nil
 }
 
-// New validates MTC proof parameters, orders signatures canonically, and returns
+// Serialize validates MTC proof parameters, orders signatures canonically, and returns
 // the TLS-encoded MTCProof binary bytes.
-func New(extensions []byte, start, end uint64, inclusionProof [][]byte, signatures []SubtreeSignature) ([]byte, error) {
+func Serialize(extensions []byte, start, end uint64, inclusionProof [][]byte, signatures []SubtreeSignature) ([]byte, error) {
 	p, err := new(extensions, start, end, inclusionProof, signatures)
 	if err != nil {
 		return nil, err
@@ -98,24 +98,21 @@ func New(extensions []byte, start, end uint64, inclusionProof [][]byte, signatur
 func new(extensions []byte, start, end uint64, inclusionProof [][]byte, signatures []SubtreeSignature) (*mtcProof, error) {
 	// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
 	// "uint48 start; uint48 end;"
-	if start > maxUint48 {
-		return nil, fmt.Errorf("start index %d exceeds uint48 maximum (%d)", start, maxUint48)
+	if start >= end {
+		return nil, fmt.Errorf("start (%d) must be strictly less than end (%d)", start, end)
 	}
 	if end > maxUint48 {
 		return nil, fmt.Errorf("end index %d exceeds uint48 maximum (%d)", end, maxUint48)
 	}
-	if start >= end {
-		return nil, fmt.Errorf("start (%d) must be strictly less than end (%d)", start, end)
-	}
 	// SPEC: draft-ietf-plants-merkle-tree-certs section 5.2.1.
 	// "opaque extension_data<0..2^16-1>; "
-	if l := len(extensions); l >= 1<<16 {
-		return nil, fmt.Errorf("extensions too large (%d bytes, max %d)", l, (1<<16)-1)
+	if limit, l := 1<<16, len(extensions); l >= limit {
+		return nil, fmt.Errorf("extensions too large (%d bytes, max %d)", l, limit-1)
 	}
 	// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
 	// "HashValue inclusion_proof<0..2^16-1>;"
-	if l := len(inclusionProof) * sha256.Size; l >= 1<<16 {
-		return nil, fmt.Errorf("inclusion proof too large (%d bytes, max %d)", l, (1<<16)-1)
+	if limit, l := 1<<16, len(inclusionProof)*sha256.Size; l >= limit {
+		return nil, fmt.Errorf("inclusion proof too large (%d bytes, max %d)", l, limit-1)
 	}
 
 	hashes := make([]hashValue, len(inclusionProof))
@@ -144,16 +141,16 @@ func new(extensions []byte, start, end uint64, inclusionProof [][]byte, signatur
 		}
 		// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
 		// "opaque signature<0..2^16-1>;"
-		if l := len(sig.Signature); l >= 1<<16 {
-			return nil, fmt.Errorf("signature too large (%d bytes, max %d)", l, (1<<16)-1)
+		if limit, l := 1<<16, len(sig.Signature); l >= limit {
+			return nil, fmt.Errorf("signature too large (%d bytes, max %d)", l, limit-1)
 		}
 		// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
 		// "SubtreeSignature signatures<0..2^16-1>;"
 		// In TLS presentation syntax, each SubtreeSignature consists of:
 		// 1 byte (length of TrustAnchorID) + len(CosignerID) + 2 bytes (length of signature) + len(Signature).
 		totalSigsLen += 1 + len(sig.CosignerID) + 2 + len(sig.Signature)
-		if totalSigsLen >= 1<<16 {
-			return nil, fmt.Errorf("signatures vector too large (%d bytes, max %d)", totalSigsLen, (1<<16)-1)
+		if limit, l := 1<<16, totalSigsLen; l >= limit {
+			return nil, fmt.Errorf("signatures vector too large (%d bytes, max %d)", totalSigsLen, limit-1)
 		}
 		// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
 		// "An MTCProof parser MUST reject the input if there are duplicate cosigner_id values,

--- a/cmd/mtc/log/internal/mtcproof/mtcproof_test.go
+++ b/cmd/mtc/log/internal/mtcproof/mtcproof_test.go
@@ -179,7 +179,7 @@ func TestCompareCosignerIDs(t *testing.T) {
 	}
 }
 
-func TestNew(t *testing.T) {
+func TestSerialize(t *testing.T) {
 	node1 := bytes.Repeat([]byte{0xaa}, sha256.Size)
 	node2 := bytes.Repeat([]byte{0xbb}, sha256.Size)
 
@@ -317,15 +317,15 @@ func TestNew(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rawBytes, err := New(tc.extensions, tc.start, tc.end, tc.inclusionProof, tc.signatures)
+			rawBytes, err := Serialize(tc.extensions, tc.start, tc.end, tc.inclusionProof, tc.signatures)
 			if (err != nil) != tc.wantErr {
-				t.Fatalf("New() error = %v, wantErr %v", err, tc.wantErr)
+				t.Fatalf("Serialize() error = %v, wantErr %v", err, tc.wantErr)
 			}
 			if tc.wantErr {
 				return
 			}
 			if len(rawBytes) == 0 {
-				t.Error("New() returned empty byte slice")
+				t.Error("Serialize() returned empty byte slice")
 			}
 
 			p, err := new(tc.extensions, tc.start, tc.end, tc.inclusionProof, tc.signatures)

--- a/cmd/mtc/log/internal/mtcproof/mtcproof_test.go
+++ b/cmd/mtc/log/internal/mtcproof/mtcproof_test.go
@@ -1,0 +1,435 @@
+// Copyright 2026 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mtcproof
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/cryptobyte"
+)
+
+// readUint48 reads a big-endian, 48-bit value from the byte string.
+func readUint48(s *cryptobyte.String, out *uint64) bool {
+	var b []byte
+	if !s.ReadBytes(&b, 6) {
+		return false
+	}
+	*out = uint64(b[0])<<40 |
+		uint64(b[1])<<32 |
+		uint64(b[2])<<24 |
+		uint64(b[3])<<16 |
+		uint64(b[4])<<8 |
+		uint64(b[5])
+	return true
+}
+
+func (p *mtcProof) unmarshal(data []byte) error {
+	s := cryptobyte.String(data)
+
+	var extensions cryptobyte.String
+	if !s.ReadUint16LengthPrefixed(&extensions) {
+		return errors.New("malformed extensions")
+	}
+	p.extensions = append([]byte(nil), extensions...)
+
+	if !readUint48(&s, &p.start) {
+		return errors.New("malformed start index")
+	}
+	if !readUint48(&s, &p.end) {
+		return errors.New("malformed end index")
+	}
+
+	var incProof cryptobyte.String
+	if !s.ReadUint16LengthPrefixed(&incProof) {
+		return errors.New("malformed inclusion_proof")
+	}
+	p.inclusionProof = nil
+	for !incProof.Empty() {
+		var hash []byte
+		if !incProof.ReadBytes(&hash, 32) {
+			return errors.New("malformed hash in inclusion_proof")
+		}
+		p.inclusionProof = append(p.inclusionProof, hashValue(hash))
+	}
+
+	var sigs cryptobyte.String
+	if !s.ReadUint16LengthPrefixed(&sigs) {
+		return errors.New("malformed signatures")
+	}
+	p.signatures = nil
+	for !sigs.Empty() {
+		var cosignerID cryptobyte.String
+		if !sigs.ReadUint8LengthPrefixed(&cosignerID) || len(cosignerID) == 0 {
+			return errors.New("malformed cosigner_id in signatures")
+		}
+		var sig cryptobyte.String
+		if !sigs.ReadUint16LengthPrefixed(&sig) {
+			return errors.New("malformed signature in signatures")
+		}
+		p.signatures = append(p.signatures, SubtreeSignature{
+			CosignerID: append([]byte(nil), cosignerID...),
+			Signature:  append([]byte(nil), sig...),
+		})
+	}
+
+	if !s.Empty() {
+		return errors.New("trailing bytes after MTCProof")
+	}
+	return nil
+}
+
+func TestMTCProof_Marshal(t *testing.T) {
+	var h1, h2 hashValue
+	copy(h1[:], bytes.Repeat([]byte{0xaa}, sha256.Size))
+	copy(h2[:], bytes.Repeat([]byte{0xbb}, sha256.Size))
+
+	tests := []struct {
+		name  string
+		proof mtcProof
+	}{
+		{
+			name: "full proof with extensions and signatures",
+			proof: mtcProof{
+				extensions:     []byte{1, 2, 3},
+				start:          3631,
+				end:            3981,
+				inclusionProof: []hashValue{h1, h2},
+				signatures: []SubtreeSignature{
+					{CosignerID: []byte("c1"), Signature: []byte("sig1")},
+					{CosignerID: []byte("c2"), Signature: []byte("sig2")},
+				},
+			},
+		},
+		{
+			name: "empty extensions and signatures",
+			proof: mtcProof{
+				start:          0,
+				end:            1,
+				inclusionProof: []hashValue{h1},
+			},
+		},
+		{
+			name: "zero-length inclusion proof and extensions",
+			proof: mtcProof{
+				start: 0,
+				end:   10,
+				signatures: []SubtreeSignature{
+					{CosignerID: []byte("c1"), Signature: []byte("sig1")},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := tc.proof.marshal()
+			if err != nil {
+				t.Fatalf("marshal() error = %v", err)
+			}
+
+			var parsed mtcProof
+			if err := parsed.unmarshal(data); err != nil {
+				t.Fatalf("unmarshal() error = %v", err)
+			}
+
+			if !reflect.DeepEqual(tc.proof, parsed) {
+				t.Errorf("unmarshal() = %+v, want %+v", parsed, tc.proof)
+			}
+		})
+	}
+}
+
+func TestCompareCosignerIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []byte
+		want int
+	}{
+		{name: "equal single byte", a: []byte("a"), b: []byte("a"), want: 0},
+		{name: "less single byte", a: []byte("a"), b: []byte("b"), want: -1},
+		{name: "greater single byte", a: []byte("b"), b: []byte("a"), want: 1},
+		{name: "shorter length comes first", a: []byte("z"), b: []byte("aa"), want: -1},
+		{name: "longer length comes after", a: []byte("aa"), b: []byte("z"), want: 1},
+		{name: "lexicographical same length", a: []byte("ab"), b: []byte("ac"), want: -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compareCosignerIDs(tc.a, tc.b)
+			if (tc.want < 0 && got >= 0) || (tc.want > 0 && got <= 0) || (tc.want == 0 && got != 0) {
+				t.Errorf("compareCosignerIDs(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	node1 := bytes.Repeat([]byte{0xaa}, sha256.Size)
+	node2 := bytes.Repeat([]byte{0xbb}, sha256.Size)
+
+	tests := []struct {
+		name           string
+		extensions     []byte
+		start          uint64
+		end            uint64
+		inclusionProof [][]byte
+		signatures     []SubtreeSignature
+		wantErr        bool
+		wantSigOrder   [][]byte
+	}{
+		{
+			name:           "valid proof with canonical signature sorting",
+			start:          0,
+			end:            10,
+			inclusionProof: [][]byte{node1, node2},
+			signatures: []SubtreeSignature{
+				{CosignerID: []byte("longest-cosigner-id"), Signature: []byte("sig3")},
+				{CosignerID: []byte("id-b"), Signature: []byte("sig2")},
+				{CosignerID: []byte("id-a"), Signature: []byte("sig1")},
+			},
+			wantSigOrder: [][]byte{
+				[]byte("id-a"),
+				[]byte("id-b"),
+				[]byte("longest-cosigner-id"),
+			},
+		},
+		{
+			name:    "start exceeds uint48 max",
+			start:   1 << 48,
+			end:     (1 << 48) + 1,
+			wantErr: true,
+		},
+		{
+			name:    "end exceeds uint48 max",
+			start:   0,
+			end:     1 << 48,
+			wantErr: true,
+		},
+		{
+			name:    "invalid range start equals end",
+			start:   10,
+			end:     10,
+			wantErr: true,
+		},
+		{
+			name:    "invalid range start greater than end",
+			start:   15,
+			end:     10,
+			wantErr: true,
+		},
+		{
+			name:       "extensions too large",
+			extensions: make([]byte, 1<<16),
+			start:      0,
+			end:        10,
+			wantErr:    true,
+		},
+		{
+			name:           "inclusion proof hash node too short",
+			start:          0,
+			end:            10,
+			inclusionProof: [][]byte{bytes.Repeat([]byte{0xaa}, sha256.Size-1)},
+			wantErr:        true,
+		},
+		{
+			name:           "inclusion proof hash node too long",
+			start:          0,
+			end:            10,
+			inclusionProof: [][]byte{bytes.Repeat([]byte{0xaa}, sha256.Size+1)},
+			wantErr:        true,
+		},
+		{
+			name:  "duplicate cosigner_id rejected",
+			start: 0,
+			end:   10,
+			signatures: []SubtreeSignature{
+				{CosignerID: []byte("id1"), Signature: []byte("sig1")},
+				{CosignerID: []byte("id1"), Signature: []byte("sig2")},
+			},
+			wantErr: true,
+		},
+		{
+			name:  "cosigner_id empty (0 bytes) rejected",
+			start: 0,
+			end:   10,
+			signatures: []SubtreeSignature{
+				{CosignerID: []byte(""), Signature: []byte("sig1")},
+			},
+			wantErr: true,
+		},
+		{
+			name:  "cosigner_id max length (255 bytes) accepted",
+			start: 0,
+			end:   10,
+			signatures: []SubtreeSignature{
+				{CosignerID: make([]byte, 255), Signature: []byte("sig1")},
+			},
+			wantErr: false,
+			wantSigOrder: [][]byte{
+				make([]byte, 255),
+			},
+		},
+		{
+			name:  "cosigner_id too long (256 bytes) rejected",
+			start: 0,
+			end:   10,
+			signatures: []SubtreeSignature{
+				{CosignerID: make([]byte, 256), Signature: []byte("sig1")},
+			},
+			wantErr: true,
+		},
+		{
+			name:  "signature too long rejected",
+			start: 0,
+			end:   10,
+			signatures: []SubtreeSignature{
+				{CosignerID: []byte("id1"), Signature: make([]byte, 1<<16)},
+			},
+			wantErr: true,
+		},
+		{
+			name:  "signatures vector too large",
+			start: 0,
+			end:   10,
+			signatures: []SubtreeSignature{
+				{CosignerID: []byte("id1"), Signature: make([]byte, (1<<16)-10)},
+				{CosignerID: []byte("id2"), Signature: make([]byte, 100)},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rawBytes, err := New(tc.extensions, tc.start, tc.end, tc.inclusionProof, tc.signatures)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("New() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if len(rawBytes) == 0 {
+				t.Error("New() returned empty byte slice")
+			}
+
+			p, err := new(tc.extensions, tc.start, tc.end, tc.inclusionProof, tc.signatures)
+			if err != nil {
+				t.Fatalf("new() error = %v", err)
+			}
+			if len(p.signatures) != len(tc.wantSigOrder) {
+				t.Fatalf("len(signatures) = %d, want %d", len(p.signatures), len(tc.wantSigOrder))
+			}
+			for i, wantID := range tc.wantSigOrder {
+				if !bytes.Equal(p.signatures[i].CosignerID, wantID) {
+					t.Errorf("signatures[%d].CosignerID = %q, want %q", i, p.signatures[i].CosignerID, wantID)
+				}
+			}
+		})
+	}
+}
+
+func TestParseCosignerID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:  "valid PEN 32473.1",
+			input: "oid/1.3.6.1.4.1.32473.1",
+			want:  []byte{0x81, 0xfd, 0x59, 0x01},
+		},
+		{
+			name:  "valid PEN 44363.47",
+			input: "oid/1.3.6.1.4.1.44363.47",
+			want:  []byte{0x82, 0xda, 0x4b, 0x2f},
+		},
+		{
+			name:  "valid PEN 0",
+			input: "oid/1.3.6.1.4.1.0",
+			want:  []byte{0x00},
+		},
+		{
+			name:  "valid PEN 1.2.3",
+			input: "oid/1.3.6.1.4.1.1.2.3",
+			want:  []byte{0x01, 0x02, 0x03},
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "missing oid prefix",
+			input:   "32473.1",
+			wantErr: true,
+		},
+		{
+			name:    "missing oid scheme prefix",
+			input:   "1.3.6.1.4.1.32473.1",
+			wantErr: true,
+		},
+		{
+			name:    "trailing dot only",
+			input:   "oid/1.3.6.1.4.1.",
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric characters",
+			input:   "oid/1.3.6.1.4.1.invalid",
+			wantErr: true,
+		},
+		{
+			name:    "alphanumeric component",
+			input:   "oid/1.3.6.1.4.1.1.2.abc",
+			wantErr: true,
+		},
+		{
+			name:    "consecutive dots",
+			input:   "oid/1.3.6.1.4.1.1..2",
+			wantErr: true,
+		},
+		{
+			name:    "wrong base OID arc",
+			input:   "oid/1.2.840.113549.1.1.1",
+			wantErr: true,
+		},
+		{
+			name:    "OID resulting in binary ID > 255 bytes rejected",
+			input:   "oid/1.3.6.1.4.1." + strings.Repeat("123456789.", 70) + "1",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseCosignerID(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseCosignerID(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("ParseCosignerID(%q) = %x, want %x", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -66,7 +66,6 @@ func RecommendedLandmarkInterval(maxCertLifetime time.Duration) time.Duration {
 }
 
 const (
-
 	// SPEC: draft-ietf-plants-merkle-tree-certs section 5.3.1.
 	// "cosigner_name and log_origin are computed from the cosigner ID and the
 	// issuance log's ID (Section 5.1), respectively. They contain the concatenation of:
@@ -162,15 +161,11 @@ type MTCLog struct {
 	maxCertLifetime   time.Duration
 }
 
-// MTCProof represents an MTC inclusion proof as per
-// draft-ietf-plants-merkle-tree-certs section 6.2.
-type MTCProof struct{}
-
 // AddTBSRsp contains enough information from the log
 // to build a standalone certificate.
 type AddTBSRsp struct {
-	Index    uint64   `json:"index"`
-	MTCProof MTCProof `json:"mtcProof"`
+	Index    uint64 `json:"index"`
+	MTCProof []byte `json:"mtcProof"`
 }
 
 // TBSCertificateLogEntry represents a log entry as per
@@ -413,18 +408,18 @@ func (l *MTCLog) AddTBS(ctx context.Context, tbs TBSCertificateLogEntry) (*AddTB
 
 	return &AddTBSRsp{
 		Index:    idx.Index,
-		MTCProof: MTCProof{},
+		MTCProof: nil,
 	}, nil
 }
 
 // ProofToLandmark builds an MTCProof for the entry at idx to a
 // published landmark.
 // TODO: better arg
-func (l *MTCLog) ProofToLandmark(ctx context.Context, idx uint64) (MTCProof, error) {
+func (l *MTCLog) ProofToLandmark(ctx context.Context, idx uint64) ([]byte, error) {
 	// TODO check if landmark is available
 	//   If available, build and return an MTCProof
 	//   If not, return a clever error
-	return MTCProof{}, nil
+	return nil, nil
 }
 
 // formatOriginAndSigner generates valid MTC origin and signerName.


### PR DESCRIPTION
Towards #945.

This PR:
 - introduces `MTCProof` and its serialization functions.
 A series of checks are done in `new` to prevent building a proof that wouldn't be specs compliant at serialization time. I've gone quite maximalists on all the checks, but I think it should be future proof. Some of them are required (for instance, making sure we don't have too many signatures), others less because they already happen somewhere else in the codebase (like the length of cosigner IDs)... but it's probably better to have them all and call it done.
 - returns `MTCProof` as `[]byte` in the public API rather than an actual proof.
 I could be convinced otherwise, though this decision is mostly rooted in that:
   - it reduces our API surface
   - this `MTCProof`, really, is a signature, and if we return `[]byte`, we comply with the MTC specs, and the CA can use this signature directly.
   - it _might_ (should, must?!) be a good idea for the CA to verify `MTCProof` before they stick it in a cert. I'm thinking that in a followup PR, we could export a `func Verify(proofBytes []byte, tbs TBSCertificateLogEntry, index uint64, origin string, verifiers []note.SubtreeVerifier) error` function, WDYT?