### PR TITLE
Bump to go1.25.13

### DIFF
--- a/cmd/conformance/aws/Dockerfile
+++ b/cmd/conformance/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-alpine3.23@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931 AS builder
+FROM golang:1.25.13-alpine3.23@sha256:4ce6af6747b07e99ca3a57eadb77565787390a41b0039dcc8e09ec4c57cfa125 AS builder
 
 ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
 ENV GOFLAGS=$GOFLAGS

--- a/cmd/conformance/gcp/Dockerfile
+++ b/cmd/conformance/gcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-alpine3.23@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931 AS builder
+FROM golang:1.25.13-alpine3.23@sha256:4ce6af6747b07e99ca3a57eadb77565787390a41b0039dcc8e09ec4c57cfa125 AS builder
 
 ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
 ENV GOFLAGS=$GOFLAGS

--- a/cmd/conformance/posix/docker/Dockerfile
+++ b/cmd/conformance/posix/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-alpine3.23@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931 AS builder
+FROM golang:1.25.13-alpine3.23@sha256:4ce6af6747b07e99ca3a57eadb77565787390a41b0039dcc8e09ec4c57cfa125 AS builder
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/transparency-dev/tessera
 
 go 1.25.8
 
-toolchain go1.25.12
+toolchain go1.25.13
 
 require (
 	cloud.google.com/go/spanner v1.94.0

--- a/internal/hammer/Dockerfile
+++ b/internal/hammer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11-alpine3.23@sha256:c05ba4b73604069d376c4f41346b05374335b5ca0c46fb6dfede5a59f5196931 AS builder
+FROM golang:1.25.13-alpine3.23@sha256:4ce6af6747b07e99ca3a57eadb77565787390a41b0039dcc8e09ec4c57cfa125 AS builder
 
 ARG GOFLAGS="-trimpath -buildvcs=false -buildmode=exe"
 ENV GOFLAGS=$GOFLAGS


### PR DESCRIPTION
This should address the `go-vulncheck` warning currently blocking PRs.