### PR TITLE
[MTC] Mirror Gateway: remove WithLogOrigin and extract origin from checkpoint

### DIFF
--- a/append_lifecycle.go
+++ b/append_lifecycle.go
@@ -860,7 +860,6 @@ func (o AppendOptions) mirrorGateway(ctx context.Context, lr LogReader, httpClie
 	mirrorGateway, err := m_gateway.NewGateway(ctx, m_gateway.Options{
 		Mirrors:    mirrorURLs,
 		LogReader:  lr,
-		LogOrigin:  o.primarySigner.Name(),
 		HTTPClient: httpClient,
 	})
 	if err != nil {

--- a/client/mirror/client.go
+++ b/client/mirror/client.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -46,7 +47,6 @@ type PackageProverFunc func(ctx context.Context, start, end, size uint64) ([][]b
 type Options struct {
 	mirrorURL               *url.URL
 	httpClient              *http.Client
-	logOrigin               string
 	tileFetcher             client.TileFetcherFunc
 	bundleFetcher           client.EntryBundleFetcherFunc
 	mirrorCheckpointFetcher client.CheckpointFetcherFunc
@@ -69,12 +69,6 @@ func (o *Options) WithMirrorURL(mirrorURL *url.URL) *Options {
 // WithHTTPClient sets the HTTP client.
 func (o *Options) WithHTTPClient(httpClient *http.Client) *Options {
 	o.httpClient = httpClient
-	return o
-}
-
-// WithLogOrigin sets the log origin.
-func (o *Options) WithLogOrigin(logOrigin string) *Options {
-	o.logOrigin = logOrigin
 	return o
 }
 
@@ -109,9 +103,6 @@ func (o *Options) validate() error {
 	}
 	if o.httpClient == nil {
 		return errors.New("HTTP client is required")
-	}
-	if o.logOrigin == "" {
-		return errors.New("log origin is required")
 	}
 	if o.tileFetcher == nil {
 		return errors.New("tile fetcher is required")
@@ -218,7 +209,7 @@ func parseConflict(r io.Reader) error {
 
 // pushEntries streams entry packages and their proofs to the mirror's /add-entries endpoint.
 // It returns the mirror's cosignatures on success.
-func (c *Client) pushEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte) ([]byte, error) {
+func (c *Client) pushEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte) ([]byte, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -227,7 +218,7 @@ func (c *Client) pushEntries(ctx context.Context, uploadStart, uploadEnd uint64,
 		_ = pr.Close()
 	}()
 
-	go c.streamEntries(ctx, uploadStart, uploadEnd, ticket, pw)
+	go c.streamEntries(ctx, origin, uploadStart, uploadEnd, ticket, pw)
 
 	u, err := c.opts.mirrorURL.Parse("add-entries")
 	if err != nil {
@@ -271,7 +262,7 @@ func (c *Client) pushEntries(ctx context.Context, uploadStart, uploadEnd uint64,
 // streamEntries serializes, compresses, and writes the log origin, upload range, ticket,
 // and the corresponding entry packages with their proofs to the pipe writer.
 // It closes the pipe writer with an error if any operation fails, or nil on success.
-func (c *Client) streamEntries(ctx context.Context, uploadStart, uploadEnd uint64, ticket []byte, pw *io.PipeWriter) {
+func (c *Client) streamEntries(ctx context.Context, origin string, uploadStart, uploadEnd uint64, ticket []byte, pw *io.PipeWriter) {
 	gw := gzip.NewWriter(pw)
 	defer func() {
 		_ = gw.Close()
@@ -279,12 +270,12 @@ func (c *Client) streamEntries(ctx context.Context, uploadStart, uploadEnd uint6
 	}()
 
 	// 2 bytes, encoding a big-endian uint16: log_origin_size
-	if err := binary.Write(gw, binary.BigEndian, uint16(len(c.opts.logOrigin))); err != nil {
+	if err := binary.Write(gw, binary.BigEndian, uint16(len(origin))); err != nil {
 		_ = pw.CloseWithError(err)
 		return
 	}
 	// log_origin_size bytes, containing the log origin: log_origin
-	if _, err := gw.Write([]byte(c.opts.logOrigin)); err != nil {
+	if _, err := gw.Write([]byte(origin)); err != nil {
 		_ = pw.CloseWithError(err)
 		return
 	}
@@ -454,9 +445,30 @@ func (c *Client) buildCheckpointRequestBody(oldSize uint64, proof [][]byte, chec
 	return &b
 }
 
+// parseOrigin extracts and validates the log origin from the first line of a raw checkpoint.
+func parseOrigin(cp []byte) (string, error) {
+	originBytes, _, ok := bytes.Cut(cp, []byte("\n"))
+	if !ok || len(originBytes) == 0 {
+		return "", errors.New("invalid checkpoint: missing origin line")
+	}
+
+	// 2 bytes, encoding a big-endian uint16: log_origin_size
+	if len(originBytes) > math.MaxUint16 {
+		return "", fmt.Errorf("invalid checkpoint: origin length %d exceeds max uint16 (%d)", len(originBytes), math.MaxUint16)
+	}
+
+	return string(originBytes), nil
+}
+
 // Sync synchronizes all entries and the checkpoint from the source log to the mirror
-// up to the specified targetSize. It returns the mirror's cosignatures on success.
+// up to the specified targetSize. targetCheckpointRaw must be a valid checkpoint starting
+// with the log origin on the first line. It returns the mirror's cosignatures on success.
 func (c *Client) Sync(ctx context.Context, targetCheckpointRaw []byte, targetSize uint64) ([]byte, error) {
+	origin, err := parseOrigin(targetCheckpointRaw)
+	if err != nil {
+		return nil, err
+	}
+
 	// Push the checkpoint with the old size (0 if not provided).
 	// Keep trying for as long as we get conflict errors (until the context expires).
 	// Ensure we send the checkpoint at least once, this serves two purposes:
@@ -494,7 +506,7 @@ func (c *Client) Sync(ctx context.Context, targetCheckpointRaw []byte, targetSiz
 	var cosigs []byte
 	for {
 		var err error
-		cosigs, err = c.pushEntries(ctx, uploadStart, uploadEnd, c.ticket)
+		cosigs, err = c.pushEntries(ctx, origin, uploadStart, uploadEnd, c.ticket)
 		if err != nil {
 			var conflict ErrConflict
 			if !errors.As(err, &conflict) {

--- a/client/mirror/client_test.go
+++ b/client/mirror/client_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -188,9 +189,6 @@ func TestNewOptions(t *testing.T) {
 	if opts.mirrorURL != nil {
 		t.Errorf("NewOptions().mirrorURL = %v, want nil", opts.mirrorURL)
 	}
-	if opts.logOrigin != "" {
-		t.Errorf("NewOptions().logOrigin = %q, want empty", opts.logOrigin)
-	}
 	if opts.tileFetcher != nil {
 		t.Errorf("NewOptions().tileFetcher = %v, want nil", opts.tileFetcher)
 	}
@@ -212,7 +210,6 @@ func TestOptionsBuilders(t *testing.T) {
 		t.Fatalf("failed to parse test URL: %v", err)
 	}
 	httpClient := &http.Client{}
-	logOrigin := "test-origin"
 	var tileFetcher client.TileFetcherFunc = func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) {
 		return nil, nil
 	}
@@ -229,7 +226,6 @@ func TestOptionsBuilders(t *testing.T) {
 	opts := NewOptions().
 		WithMirrorURL(u).
 		WithHTTPClient(httpClient).
-		WithLogOrigin(logOrigin).
 		WithTileFetcher(tileFetcher).
 		WithBundleFetcher(bundleFetcher).
 		WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
@@ -240,9 +236,6 @@ func TestOptionsBuilders(t *testing.T) {
 	}
 	if opts.httpClient != httpClient {
 		t.Errorf("WithHTTPClient() = %v, want %v", opts.httpClient, httpClient)
-	}
-	if opts.logOrigin != logOrigin {
-		t.Errorf("WithLogOrigin() = %q, want %q", opts.logOrigin, logOrigin)
 	}
 	if opts.tileFetcher == nil {
 		t.Errorf("WithTileFetcher() tileFetcher is nil")
@@ -262,7 +255,6 @@ func TestOptionsBuilders(t *testing.T) {
 func TestNewClientValidation(t *testing.T) {
 	u, _ := url.Parse("https://example.com")
 	httpClient := &http.Client{}
-	logOrigin := "test-origin"
 	var tileFetcher client.TileFetcherFunc = func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) { return nil, nil }
 	var bundleFetcher client.EntryBundleFetcherFunc = func(ctx context.Context, index uint64, size uint8) ([]byte, error) { return nil, nil }
 	var mirrorCheckpointFetcher client.CheckpointFetcherFunc = func(ctx context.Context) ([]byte, error) { return nil, nil }
@@ -278,7 +270,6 @@ func TestNewClientValidation(t *testing.T) {
 				return NewOptions().
 					WithMirrorURL(u).
 					WithHTTPClient(httpClient).
-					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
 					WithBundleFetcher(bundleFetcher).
 					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
@@ -289,7 +280,6 @@ func TestNewClientValidation(t *testing.T) {
 			setup: func() *Options {
 				return NewOptions().
 					WithHTTPClient(httpClient).
-					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
 					WithBundleFetcher(bundleFetcher).
 					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
@@ -301,7 +291,6 @@ func TestNewClientValidation(t *testing.T) {
 			setup: func() *Options {
 				opts := NewOptions().
 					WithMirrorURL(u).
-					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
 					WithBundleFetcher(bundleFetcher).
 					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
@@ -311,24 +300,11 @@ func TestNewClientValidation(t *testing.T) {
 			wantErr: "HTTP client is required",
 		},
 		{
-			desc: "missing log origin",
-			setup: func() *Options {
-				return NewOptions().
-					WithMirrorURL(u).
-					WithHTTPClient(httpClient).
-					WithTileFetcher(tileFetcher).
-					WithBundleFetcher(bundleFetcher).
-					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
-			},
-			wantErr: "log origin is required",
-		},
-		{
 			desc: "missing tile fetcher",
 			setup: func() *Options {
 				return NewOptions().
 					WithMirrorURL(u).
 					WithHTTPClient(httpClient).
-					WithLogOrigin(logOrigin).
 					WithBundleFetcher(bundleFetcher).
 					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
 			},
@@ -340,7 +316,6 @@ func TestNewClientValidation(t *testing.T) {
 				return NewOptions().
 					WithMirrorURL(u).
 					WithHTTPClient(httpClient).
-					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
 					WithMirrorCheckpointFetcher(mirrorCheckpointFetcher)
 			},
@@ -352,7 +327,6 @@ func TestNewClientValidation(t *testing.T) {
 				return NewOptions().
 					WithMirrorURL(u).
 					WithHTTPClient(httpClient).
-					WithLogOrigin(logOrigin).
 					WithTileFetcher(tileFetcher).
 					WithBundleFetcher(bundleFetcher)
 			},
@@ -420,7 +394,7 @@ func newFakeMirror(t *testing.T, origin string) *fakeMirror {
 		t:                   t,
 		origin:              origin,
 		ticket:              []byte("ticket-value"),
-		targetCheckpoint:    []byte("checkpoint-raw-bytes"),
+		targetCheckpoint:    []byte(origin + "\ncheckpoint-raw-bytes\n"),
 		expectedCosigs:      []byte("mock-cosignatures"),
 		numEntries:          5,
 		proofHashes:         [][]byte{bytes.Repeat([]byte{1}, 32)},
@@ -695,7 +669,7 @@ func TestSync(t *testing.T) {
 			},
 			steps: []syncStep{
 				{
-					checkpoint:   []byte("checkpoint-raw-bytes"),
+					checkpoint:   []byte(origin + "\ncheckpoint-raw-bytes\n"),
 					targetSize:   5,
 					expectCosigs: []byte("mock-cosignatures"),
 				},
@@ -719,12 +693,12 @@ func TestSync(t *testing.T) {
 			},
 			steps: []syncStep{
 				{
-					checkpoint:   []byte("checkpoint-raw-bytes"),
+					checkpoint:   []byte(origin + "\ncheckpoint-raw-bytes\n"),
 					targetSize:   5,
 					expectCosigs: []byte("mock-cosignatures"),
 				},
 				{
-					checkpoint:   []byte("checkpoint-raw-bytes"),
+					checkpoint:   []byte(origin + "\ncheckpoint-raw-bytes\n"),
 					targetSize:   5,
 					expectCosigs: []byte("mock-cosignatures"),
 					beforeSync: func(fm *fakeMirror) {
@@ -770,7 +744,6 @@ func TestSync(t *testing.T) {
 
 			opts := NewOptions().
 				WithMirrorURL(u).
-				WithLogOrigin(origin).
 				WithTileFetcher(tileFetcher).
 				WithBundleFetcher(bundleFetcher).
 				WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
@@ -1044,7 +1017,6 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 
 			opts := NewOptions().
 				WithMirrorURL(u).
-				WithLogOrigin(origin).
 				WithTileFetcher(tf).
 				WithBundleFetcher(bundleFetcher).
 				WithMirrorCheckpointFetcher(mirrorCheckpointFetcher).
@@ -1072,6 +1044,97 @@ func TestSync_ErrorsAndEdgeCases(t *testing.T) {
 
 			if !bytes.Equal(cosigs, fm.expectedCosigs) {
 				t.Errorf("Sync() = %q, want %q", string(cosigs), string(fm.expectedCosigs))
+			}
+		})
+	}
+}
+
+func TestParseOrigin(t *testing.T) {
+	tests := []struct {
+		name       string
+		checkpoint []byte
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "valid origin",
+			checkpoint: []byte("example.com/log\n100\n"),
+			want:       "example.com/log",
+		},
+		{
+			name:       "empty checkpoint",
+			checkpoint: []byte(""),
+			wantErr:    true,
+		},
+		{
+			name:       "no newline",
+			checkpoint: []byte("invalid-checkpoint-no-newline"),
+			wantErr:    true,
+		},
+		{
+			name:       "empty origin line",
+			checkpoint: []byte("\n100\n"),
+			wantErr:    true,
+		},
+		{
+			name:       "origin exceeds max uint16",
+			checkpoint: append(bytes.Repeat([]byte("a"), math.MaxUint16+1), []byte("\n100\n")...),
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseOrigin(tc.checkpoint)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseOrigin() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("parseOrigin() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSyncInvalidCheckpoint(t *testing.T) {
+	u, _ := url.Parse("https://example.com")
+	opts := NewOptions().
+		WithMirrorURL(u).
+		WithTileFetcher(func(ctx context.Context, level, index uint64, p uint8) ([]byte, error) { return nil, nil }).
+		WithBundleFetcher(func(ctx context.Context, index uint64, size uint8) ([]byte, error) { return nil, nil }).
+		WithMirrorCheckpointFetcher(func(ctx context.Context) ([]byte, error) { return nil, nil })
+	c, err := NewClient(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("NewClient() = _, %v, want _, nil", err)
+	}
+
+	tests := []struct {
+		desc       string
+		checkpoint []byte
+	}{
+		{
+			desc:       "empty checkpoint",
+			checkpoint: []byte(""),
+		},
+		{
+			desc:       "no newline",
+			checkpoint: []byte("invalid-checkpoint-with-no-newline"),
+		},
+		{
+			desc:       "empty origin line",
+			checkpoint: []byte("\n100\n"),
+		},
+		{
+			desc:       "origin line exceeds max uint16",
+			checkpoint: append(bytes.Repeat([]byte("a"), math.MaxUint16+1), []byte("\n100\n")...),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			_, err := c.Sync(context.Background(), tc.checkpoint, 0)
+			if err == nil {
+				t.Errorf("Sync() with %s succeeded, want error", tc.desc)
 			}
 		})
 	}

--- a/internal/mirror/gateway/mirror_gateway.go
+++ b/internal/mirror/gateway/mirror_gateway.go
@@ -68,8 +68,6 @@ type Options struct {
 	Mirrors []*url.URL
 	// LogReader provides access to the main log.
 	LogReader LogReader
-	// LogOrigin is the origin ID of the log.
-	LogOrigin string
 }
 
 // NewGateway creates a new Gateway that will keep mirrors up-to-date.
@@ -80,9 +78,6 @@ func NewGateway(ctx context.Context, opts Options) (*Gateway, error) {
 	if opts.HTTPClient == nil {
 		slog.WarnContext(ctx, "MirrorGateway: No HTTP client configured, using DefaultHTTPClient")
 		opts.HTTPClient = http.DefaultClient
-	}
-	if opts.LogOrigin == "" {
-		return nil, fmt.Errorf("log origin is required")
 	}
 	if opts.LogReader == nil {
 		return nil, fmt.Errorf("log reader is required")
@@ -103,7 +98,6 @@ func NewGateway(ctx context.Context, opts Options) (*Gateway, error) {
 		mOpts := mirror.NewOptions().
 			WithMirrorURL(u).
 			WithHTTPClient(opts.HTTPClient).
-			WithLogOrigin(opts.LogOrigin).
 			WithTileFetcher(opts.LogReader.ReadTile).
 			WithBundleFetcher(opts.LogReader.ReadEntryBundle).
 			WithMirrorCheckpointFetcher(mirrorFetcher.ReadCheckpoint)

--- a/internal/mirror/gateway/mirror_gateway_test.go
+++ b/internal/mirror/gateway/mirror_gateway_test.go
@@ -101,7 +101,6 @@ func TestGateway(t *testing.T) {
 				HTTPClient: http.DefaultClient,
 				Mirrors:    mirrorURLs,
 				LogReader:  testLog.LogReader,
-				LogOrigin:  "test",
 			})
 			if err != nil {
 				t.Fatalf("failed to create gateway: %v", err)

--- a/internal/mirror/hammer/hammer.go
+++ b/internal/mirror/hammer/hammer.go
@@ -149,7 +149,6 @@ func main() {
 		mOpts := mirror.NewOptions().
 			WithMirrorURL(mURL).
 			WithHTTPClient(hc).
-			WithLogOrigin(origin).
 			WithTileFetcher(logReader.ReadTile).
 			WithBundleFetcher(logReader.ReadEntryBundle).
 			WithMirrorCheckpointFetcher(func(ctx context.Context) ([]byte, error) {


### PR DESCRIPTION
Ultimately [fixing erroneous `LogOrigin`](https://github.com/transparency-dev/tessera/blob/main/append_lifecycle.go#L863).