### PR TITLE
Refactor mirror library

### DIFF
--- a/cmd/mtc/mirror/mirror.go
+++ b/cmd/mtc/mirror/mirror.go
@@ -1,0 +1,95 @@
+// Copyright 2026 The Tessera Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mirror provides functionality for creating and running tlog-mirror services.
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	fnote "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/handler"
+	witnessConfig "github.com/transparency-dev/witness/config"
+	"github.com/transparency-dev/witness/witness"
+	"golang.org/x/mod/sumdb/note"
+)
+
+// LogConfig represents a log to be mirrored.
+type LogConfig struct {
+	// Log is the information about the log itself.
+	Log witnessConfig.Log
+	// Driver is the Tessera Driver which should be used for storing the mirrored log.
+	Driver tessera.Driver
+}
+
+// Mirror represents an instance of a mirror service.
+//
+// This struct implements the http.Handler interface and so can be directly used to serve HTTP requests.
+type Mirror struct {
+	handler http.Handler
+}
+
+// New creates a new mirror instance with the provided configuration.
+func New(ctx context.Context, w *witness.Witness, mirrorCosigner fnote.SubtreeSigner, cfg []LogConfig) (*Mirror, error) {
+	if err := assertDistinctSigners(w.Signers, []note.Signer{mirrorCosigner}); err != nil {
+		return nil, err
+	}
+	mux := handler.NewMirrorMux()
+	for _, l := range cfg {
+		// Create the mirror
+		mOpts := tessera.NewMirrorOptions().
+			WithCheckpointSource(func(ctx context.Context) ([]byte, error) {
+				return w.GetCheckpoint(ctx, l.Log.Origin)
+			}).
+			WithOrigin(l.Log.Origin).
+			WithLogVerifier(l.Log.Verifier).
+			WithSigner(mirrorCosigner)
+		t, err := tessera.NewMirrorTarget(ctx, l.Driver, mOpts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create mirror target %q: %w", l.Log.Origin, err)
+		}
+		if err := mux.AddTarget(l.Log.Origin, t); err != nil {
+			return nil, fmt.Errorf("failed to add target %q to mux: %w", l.Log.Origin, err)
+		}
+	}
+	return &Mirror{
+		handler: handler.New(mux, w),
+	}, nil
+}
+
+// ServeHTTP implements the http.Handler interface, and exposes the tlog-mirror protocol via HTTP.
+func (m *Mirror) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.handler.ServeHTTP(w, r)
+}
+
+// assertDistinctSigners asserts that the two provided lists of cosigners have no signers in common.
+func assertDistinctSigners(w, m []note.Signer) error {
+	type nhKey struct {
+		name string
+		hash uint32
+	}
+	aMap := make(map[nhKey]struct{}, len(w))
+	for _, s := range w {
+		aMap[nhKey{name: s.Name(), hash: s.KeyHash()}] = struct{}{}
+	}
+	for _, s := range m {
+		if _, ok := aMap[nhKey{name: s.Name(), hash: s.KeyHash()}]; ok {
+			return fmt.Errorf("cannot use same signing key for witness and mirror: name=%s, hash=%x", s.Name(), s.KeyHash())
+		}
+	}
+	return nil
+}

--- a/cmd/mtc/mirror/mirror_test.go
+++ b/cmd/mtc/mirror/mirror_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 The Tessera Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mirror
+
+import (
+	"testing"
+
+	"golang.org/x/mod/sumdb/note"
+)
+
+type fakeSigner struct {
+	name    string
+	keyHash uint32
+}
+
+func (s fakeSigner) Name() string {
+	return s.name
+}
+
+func (s fakeSigner) KeyHash() uint32 {
+	return s.keyHash
+}
+
+func (s fakeSigner) Sign([]byte) ([]byte, error) {
+	return nil, nil
+}
+
+func TestAssertDistinctSigners(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		w       []note.Signer
+		m       []note.Signer
+		wantErr bool
+	}{
+		{
+			desc:    "both empty",
+			w:       nil,
+			m:       nil,
+			wantErr: false,
+		},
+		{
+			desc:    "empty witness signers",
+			w:       nil,
+			m:       []note.Signer{fakeSigner{name: "mirror1", keyHash: 1}},
+			wantErr: false,
+		},
+		{
+			desc:    "empty mirror signers",
+			w:       []note.Signer{fakeSigner{name: "wit1", keyHash: 1}},
+			m:       nil,
+			wantErr: false,
+		},
+		{
+			desc: "distinct signers with different names and hashes",
+			w: []note.Signer{
+				fakeSigner{name: "wit1", keyHash: 1},
+			},
+			m: []note.Signer{
+				fakeSigner{name: "mirror1", keyHash: 2},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "distinct signers with same name but different hashes",
+			w: []note.Signer{
+				fakeSigner{name: "signer1", keyHash: 1},
+			},
+			m: []note.Signer{
+				fakeSigner{name: "signer1", keyHash: 2},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "distinct signers with different names but same hash",
+			w: []note.Signer{
+				fakeSigner{name: "signer1", keyHash: 1},
+			},
+			m: []note.Signer{
+				fakeSigner{name: "signer2", keyHash: 1},
+			},
+			wantErr: false,
+		},
+		{
+			desc: "overlapping signer with same name and hash",
+			w: []note.Signer{
+				fakeSigner{name: "signer1", keyHash: 1},
+			},
+			m: []note.Signer{
+				fakeSigner{name: "signer1", keyHash: 1},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "multiple signers with one overlapping",
+			w: []note.Signer{
+				fakeSigner{name: "wit1", keyHash: 1},
+				fakeSigner{name: "shared", keyHash: 2},
+			},
+			m: []note.Signer{
+				fakeSigner{name: "mirror1", keyHash: 3},
+				fakeSigner{name: "shared", keyHash: 2},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "multiple signers with no overlap",
+			w: []note.Signer{
+				fakeSigner{name: "wit1", keyHash: 1},
+				fakeSigner{name: "wit2", keyHash: 2},
+			},
+			m: []note.Signer{
+				fakeSigner{name: "mirror1", keyHash: 3},
+				fakeSigner{name: "mirror2", keyHash: 4},
+			},
+			wantErr: false,
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			err := assertDistinctSigners(test.w, test.m)
+			if (err != nil) != test.wantErr {
+				t.Errorf("assertDistinctSigners() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/mtc/mirror/posix/main.go
+++ b/cmd/mtc/mirror/posix/main.go
@@ -28,8 +28,7 @@ import (
 	"time"
 
 	fnote "github.com/transparency-dev/formats/note"
-	"github.com/transparency-dev/tessera"
-	"github.com/transparency-dev/tessera/cmd/mtc/mirror/internal/handler"
+	"github.com/transparency-dev/tessera/cmd/mtc/mirror"
 	"github.com/transparency-dev/tessera/storage/posix"
 	witnessConfig "github.com/transparency-dev/witness/config"
 	"github.com/transparency-dev/witness/persistence/sqlite"
@@ -71,34 +70,19 @@ func main() {
 
 	mirrorCosigner := mustCreateCosigner(ctx, *mirrorCosignerPath)
 
-	// Mirror cosigner MUST NOT use the same key as add-checkpoint cosigner.
-	assertDistinctSigners(ctx, w.Signers, []note.Signer{mirrorCosigner})
-
-	mux := handler.NewMirrorMux()
 	cfg := mirrorConfigFromFlags(ctx)
 	for _, l := range cfg {
-		origin := l.Origin
-		v := l.Verifier
-
-		// Create the mirror
-		t, err := newMirrorTarget(ctx, w, origin, v, mirrorCosigner)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to create mirror target", slog.String("origin", origin), slog.Any("error", err))
-			os.Exit(1)
-		}
-		if err := mux.AddTarget(origin, t); err != nil {
-			slog.ErrorContext(ctx, "Failed to add target to mux", slog.String("origin", origin), slog.Any("error", err))
-			os.Exit(1)
-		}
-
 		// Ensure log is known by the witness
-		if err := wp.AddLogs(ctx, []witnessConfig.Log{l}); err != nil {
-			slog.ErrorContext(ctx, "Failed to add target log to witness", slog.String("origin", origin), slog.Any("error", err))
+		if err := wp.AddLogs(ctx, []witnessConfig.Log{l.Log}); err != nil {
+			slog.ErrorContext(ctx, "Failed to add target log to witness", slog.String("origin", l.Log.Origin), slog.Any("error", err))
 			os.Exit(1)
 		}
 	}
-
-	h := handler.New(mux, w)
+	m, err := mirror.New(ctx, w, mirrorCosigner, cfg)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to create mirror", slog.Any("error", err))
+		os.Exit(1)
+	}
 
 	var protocols http.Protocols
 	protocols.SetHTTP1(true)
@@ -106,7 +90,7 @@ func main() {
 
 	server := &http.Server{
 		Addr:              *listenAddr,
-		Handler:           h,
+		Handler:           m,
 		Protocols:         &protocols,
 		ReadHeaderTimeout: *readHeaderTimeout,
 		IdleTimeout:       *idleTimeout,
@@ -122,35 +106,9 @@ func main() {
 	}
 }
 
-// newMirrorTarget creates a new POSIX driver and MirrorTarget for the given origin.
-//
-// The target directory for the driver is derived from the storage directory and the origin in accordance
-// with the `tlog-mirror` spec, allowing the root of the storage directory to be exported directly to read-only clients.
-func newMirrorTarget(ctx context.Context, w *witness.Witness, origin string, logVerifier note.Verifier, mirrorSigner fnote.SubtreeSigner) (*tessera.MirrorTarget, error) {
-	if origin == "" {
-		return nil, fmt.Errorf("origin cannot be empty")
-	}
-	targetDir := filepath.Join(*storageDir, mirrorsDir, fmt.Sprintf("%0x", sha256.Sum256([]byte(origin))))
-	if err := os.MkdirAll(targetDir, 0o755); err != nil {
-		return nil, fmt.Errorf("mkdir %q: %v", targetDir, err)
-	}
-	d, err := posix.New(ctx, posix.Config{Path: targetDir})
-	if err != nil {
-		return nil, fmt.Errorf("posix.New: %v", err)
-	}
-	mOpts := tessera.NewMirrorOptions().
-		WithCheckpointSource(func(ctx context.Context) ([]byte, error) {
-			return w.GetCheckpoint(ctx, origin)
-		}).
-		WithOrigin(origin).
-		WithLogVerifier(logVerifier).
-		WithSigner(mirrorSigner)
-	return tessera.NewMirrorTarget(ctx, d, mOpts)
-}
-
 // mirrorConfigFromFlags returns a mirror configuration loaded from the provided flags.
 // Exits if the mirror configuration could not be loaded.
-func mirrorConfigFromFlags(ctx context.Context) []witnessConfig.Log {
+func mirrorConfigFromFlags(ctx context.Context) []mirror.LogConfig {
 	if *mirrorConfigPath == "" {
 		slog.ErrorContext(ctx, "Mirror config path not specified")
 		os.Exit(1)
@@ -166,6 +124,7 @@ func mirrorConfigFromFlags(ctx context.Context) []witnessConfig.Log {
 		os.Exit(1)
 	}
 	seenOrigins := make(map[string]struct{})
+	ret := make([]mirror.LogConfig, 0, len(cfg))
 	for _, c := range cfg {
 		o := c.Origin
 		if o == "" {
@@ -176,8 +135,22 @@ func mirrorConfigFromFlags(ctx context.Context) []witnessConfig.Log {
 			os.Exit(1)
 		}
 		seenOrigins[o] = struct{}{}
+		targetDir := filepath.Join(*storageDir, mirrorsDir, fmt.Sprintf("%0x", sha256.Sum256([]byte(o))))
+		if err := os.MkdirAll(targetDir, 0o755); err != nil {
+			slog.ErrorContext(ctx, "Failed to create mirror target", slog.String("origin", o), slog.Any("error", err))
+			os.Exit(1)
+		}
+		d, err := posix.New(ctx, posix.Config{Path: targetDir})
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to create mirror target", slog.String("origin", o), slog.Any("error", err))
+			os.Exit(1)
+		}
+		ret = append(ret, mirror.LogConfig{
+			Log:    c,
+			Driver: d,
+		})
 	}
-	return cfg
+	return ret
 }
 
 // witnessFromFlags returns a witness instance configured from the provided flags.
@@ -246,22 +219,4 @@ func mustCreateCosigner(ctx context.Context, path string) fnote.SubtreeSigner {
 		os.Exit(1)
 	}
 	return s
-}
-
-// assertDistinctSigners asserts that the two provided lists of cosigners have no signers in common.
-func assertDistinctSigners(ctx context.Context, w, m []note.Signer) {
-	type nhKey struct {
-		name string
-		hash uint32
-	}
-	aMap := make(map[nhKey]struct{}, len(w))
-	for _, s := range w {
-		aMap[nhKey{name: s.Name(), hash: s.KeyHash()}] = struct{}{}
-	}
-	for _, s := range m {
-		if _, ok := aMap[nhKey{name: s.Name(), hash: s.KeyHash()}]; ok {
-			slog.ErrorContext(ctx, "Cannot use same signing key for witness and mirror", slog.String("name", s.Name()), slog.String("hash", fmt.Sprintf("%08x", s.KeyHash())))
-			os.Exit(1)
-		}
-	}
 }

--- a/cmd/mtc/mirror/posix/main.go
+++ b/cmd/mtc/mirror/posix/main.go
@@ -106,8 +106,8 @@ func main() {
 	}
 }
 
-// mirrorConfigFromFlags returns a mirror configuration loaded from the provided flags.
-// Exits if the mirror configuration could not be loaded.
+// mirrorConfigFromFlags returns a slice of mirror.LogConfig structs, using flags as the source of information.
+// Exits if the mirror configuration could not be transformed into a slice of mirror.LogConfig structs.
 func mirrorConfigFromFlags(ctx context.Context) []mirror.LogConfig {
 	if *mirrorConfigPath == "" {
 		slog.ErrorContext(ctx, "Mirror config path not specified")


### PR DESCRIPTION
This PR does a small refactor of the MTC mirror binary, adding a simple API for instantiating a mirror service.

This is intended to make it easier to re-use when creating other binaries (e.g. other storage implementations, or tests).

Towards #945 