### PR TITLE
Mirror integration test

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Start Docker services (tessera-conformance-posix)
         run: docker compose -f ./cmd/conformance/posix/docker/compose.yaml up --build --detach
       - name: Run integration test 
-        run: go test -v -race ./integration/. --run_integration_test=true --log_url="file:///tmp/tessera-posix-log" --write_log_url="http://localhost:2025" --log_public_key="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
+        run: go test -v -race ./integration/log --run_integration_test=true --log_url="file:///tmp/tessera-posix-log" --write_log_url="http://localhost:2025" --log_public_key="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
       - name: What's in the box?
         if: ${{ always() }}
         run: tree /tmp/tessera-posix-log

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       - name: Start Docker services (tessera-conformance-posix)
         run: docker compose -f ./cmd/conformance/posix/docker/compose.yaml up --build --detach
-      - name: Run integration test 
+      - name: Run log integration test 
         run: go test -v -race ./integration/log --run_integration_test=true --log_url="file:///tmp/tessera-posix-log" --write_log_url="http://localhost:2025" --log_public_key="example.com/log/testdata+33d7b496+AeHTu4Q3hEIMHNqc6fASMsq3rKNx280NI+oO5xCFkkSx"
       - name: What's in the box?
         if: ${{ always() }}

--- a/integration/log/integration_test.go
+++ b/integration/log/integration_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 The Tessera authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package integration contains some integration tests which are intended to
+// serve as a way of checking that example binary works as intended,
+// as well as providing a simple example of how to run and use it.
+package log
+
+import (
+	"context"
+	"flag"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"log/slog"
+
+	fNote "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/tessera/client"
+
+	"golang.org/x/mod/sumdb/note"
+)
+
+var (
+	runIntegrationTest = flag.Bool("run_integration_test", false, "If true, the integration tests in this package will not be skipped")
+	logURL             = flag.String("log_url", "http://localhost:2024", "Log storage read root URL, e.g. https://log.server/and/path/")
+	writeLogURL        = flag.String("write_log_url", "http://localhost:2024", "Log storage write root URL, e.g. https://log.server/and/path/")
+	logPublicKey       = flag.String("log_public_key", "", "The log's public key value for checkpoint note verification")
+	testEntrySize      = flag.Int("test_entry_size", 1024, "The number of entries to be tested in the live log integration")
+
+	noteVerifier note.Verifier
+
+	logReadBaseURL     *url.URL
+	logReadCP          client.CheckpointFetcherFunc
+	logReadTile        client.TileFetcherFunc
+	logReadEntryBundle client.EntryBundleFetcherFunc
+
+	hc = &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        256,
+			MaxIdleConnsPerHost: 256,
+		},
+		Timeout: 60 * time.Second,
+	}
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if !*runIntegrationTest {
+		slog.WarnContext(context.Background(), "example binary integration tests are skipped")
+		return
+	}
+
+	var err error
+	noteVerifier, err = fNote.NewVerifier(*logPublicKey)
+	if err != nil {
+		slog.ErrorContext(context.Background(), "Failed to create new verifier", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	logReadBaseURL, err = url.Parse(*logURL)
+	if err != nil {
+		slog.ErrorContext(context.Background(), "failed to parse logURL", slog.Any("error", err))
+		os.Exit(1)
+	}
+	switch logReadBaseURL.Scheme {
+	case "http", "https":
+		hf, err := client.NewHTTPFetcher(logReadBaseURL, nil)
+		if err != nil {
+			slog.ErrorContext(context.Background(), "NewHTTPFetcher", slog.Any("error", err))
+			os.Exit(1)
+		}
+		logReadCP = hf.ReadCheckpoint
+		logReadTile = hf.ReadTile
+		logReadEntryBundle = hf.ReadEntryBundle
+	case "file":
+		ff := client.FileFetcher{Root: logReadBaseURL.Path}
+		logReadCP = ff.ReadCheckpoint
+		logReadTile = ff.ReadTile
+		logReadEntryBundle = ff.ReadEntryBundle
+	default:
+		slog.ErrorContext(context.Background(), "unsupported url scheme", slog.String("scheme", logReadBaseURL.Scheme))
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestLiveLogIntegration(t *testing.T) {
+	LogIntegrationTest(t, LogIntegrationTestConfig{
+		LogReadTile:        logReadTile,
+		LogReadCP:          logReadCP,
+		LogReadEntryBundle: logReadEntryBundle,
+		WriteLogURL:        *writeLogURL,
+		LogVerifier:        noteVerifier,
+		HTTPClient:         hc,
+		EntrySize:          uint64(*testEntrySize),
+	})
+}

--- a/integration/log/log_integration.go
+++ b/integration/log/log_integration.go
@@ -1,4 +1,4 @@
-// Copyright 2024 The Tessera authors. All Rights Reserved.
+// Copyright 2026 The Tessera Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,129 +12,73 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package integration_test contains some integration tests which are intended to
-// serve as a way of checking that example binary works as intended,
-// as well as providing a simple example of how to run and use it.
-package integration_test
+// Package log contains integration tests for a log.
+package log
 
 import (
 	"bytes"
 	"context"
-	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
-	"log/slog"
-
-	f_note "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tessera/client"
-
 	"golang.org/x/mod/sumdb/note"
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	runIntegrationTest = flag.Bool("run_integration_test", false, "If true, the integration tests in this package will not be skipped")
-	logURL             = flag.String("log_url", "http://localhost:2024", "Log storage read root URL, e.g. https://log.server/and/path/")
-	writeLogURL        = flag.String("write_log_url", "http://localhost:2024", "Log storage write root URL, e.g. https://log.server/and/path/")
-	logPublicKey       = flag.String("log_public_key", "", "The log's public key value for checkpoint note verification")
-	testEntrySize      = flag.Int("test_entry_size", 1024, "The number of entries to be tested in the live log integration")
+type LogIntegrationTestConfig struct {
+	LogReadTile        client.TileFetcherFunc
+	LogReadCP          client.CheckpointFetcherFunc
+	LogReadEntryBundle client.EntryBundleFetcherFunc
+	WriteLogURL        string
+	LogVerifier        note.Verifier
+	HTTPClient         *http.Client
 
-	noteVerifier note.Verifier
-
-	logReadBaseURL     *url.URL
-	logReadCP          client.CheckpointFetcherFunc
-	logReadTile        client.TileFetcherFunc
-	logReadEntryBundle client.EntryBundleFetcherFunc
-
-	hc = &http.Client{
-		Transport: &http.Transport{
-			MaxIdleConns:        256,
-			MaxIdleConnsPerHost: 256,
-		},
-		Timeout: 60 * time.Second,
-	}
-)
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-
-	if !*runIntegrationTest {
-		slog.WarnContext(context.Background(), "example binary integration tests are skipped")
-		return
-	}
-
-	var err error
-	noteVerifier, err = f_note.NewVerifier(*logPublicKey)
-	if err != nil {
-		slog.ErrorContext(context.Background(), "Failed to create new verifier", slog.Any("error", err))
-		os.Exit(1)
-	}
-
-	logReadBaseURL, err = url.Parse(*logURL)
-	if err != nil {
-		slog.ErrorContext(context.Background(), "failed to parse logURL", slog.Any("error", err))
-		os.Exit(1)
-	}
-
-	switch logReadBaseURL.Scheme {
-	case "http", "https":
-		hf, err := client.NewHTTPFetcher(logReadBaseURL, nil)
-		if err != nil {
-			slog.ErrorContext(context.Background(), "NewHTTPFetcher", slog.Any("error", err))
-			os.Exit(1)
-		}
-		logReadCP = hf.ReadCheckpoint
-		logReadTile = hf.ReadTile
-		logReadEntryBundle = hf.ReadEntryBundle
-	case "file":
-		ff := client.FileFetcher{Root: logReadBaseURL.Path}
-		logReadCP = ff.ReadCheckpoint
-		logReadTile = ff.ReadTile
-		logReadEntryBundle = ff.ReadEntryBundle
-	default:
-		slog.ErrorContext(context.Background(), "unsupported url scheme", slog.String("scheme", logReadBaseURL.Scheme))
-		os.Exit(1)
-	}
-
-	os.Exit(m.Run())
+	EntrySize uint64
 }
 
-func TestLiveLogIntegration(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+// LogIntegrationTest performs the live log integration test.
+func LogIntegrationTest(t *testing.T, cfg LogIntegrationTestConfig) {
+	t.Helper()
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = http.DefaultClient
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
 	var entryIndexMap sync.Map
 
 	// Step 1 - Get checkpoint initial size for increment validation.
-	lst, err := client.NewLogStateTracker(ctx, logReadTile, nil, noteVerifier, noteVerifier.Name(), client.UnilateralConsensus(logReadCP))
+	lst, err := client.NewLogStateTracker(ctx, cfg.LogReadTile, nil, cfg.LogVerifier, cfg.LogVerifier.Name(), client.UnilateralConsensus(cfg.LogReadCP))
 	if err != nil {
 		t.Fatalf("client.NewLogStateTracker: %v", err)
 	}
 	checkpointInitSize := lst.Latest().Size
 
 	// Step 2 - Add entries and get new checkpoints. The entry data comes from the int loop ranging from 0 to the test entry size - 1.
-	addEntriesURL, err := url.JoinPath(*writeLogURL, "add")
+	addEntriesURL, err := url.JoinPath(cfg.WriteLogURL, "add")
 	if err != nil {
 		t.Errorf("url.JoinPath: %v", err)
 	}
 	entryWriter := entryWriter{
+		hc:     cfg.HTTPClient,
 		addURL: addEntriesURL,
 	}
 	var miMu sync.Mutex
 	var maxIndex uint64
 	errG := errgroup.Group{}
-	for i := range *testEntrySize {
+	for i := range cfg.EntrySize {
 		errG.Go(func() error {
 			index, err := entryWriter.add(ctx, fmt.Appendf(nil, "%d", i))
 			if err != nil {
@@ -162,17 +106,17 @@ func TestLiveLogIntegration(t *testing.T) {
 	}
 
 	gotIncrease := lst.Latest().Size - checkpointInitSize
-	if gotIncrease < uint64(*testEntrySize) {
-		t.Logf("checkpoint size increase (%d) is < %d, entries may have been deduplicated.", gotIncrease, *testEntrySize)
+	if gotIncrease < cfg.EntrySize {
+		t.Logf("checkpoint size increase (%d) is < %d, entries may have been deduplicated.", gotIncrease, cfg.EntrySize)
 	}
 
 	// Step 3 - Loop through the entry data index map to verify leaves and inclusion proofs.
 	entryIndexMap.Range(func(k, v any) bool {
-		data := k.(int)
+		data := k.(uint64)
 		index := v.(uint64)
 
 		// Step 4.1 - Get entry bundles to read back what was written, check leaves are correct.
-		entryBundle, err := client.GetEntryBundle(ctx, logReadEntryBundle, index/layout.EntryBundleWidth, lst.Latest().Size)
+		entryBundle, err := client.GetEntryBundle(ctx, cfg.LogReadEntryBundle, index/layout.EntryBundleWidth, lst.Latest().Size)
 		if err != nil {
 			t.Fatalf("client.GetEntryBundle: %v", err)
 		}
@@ -183,7 +127,7 @@ func TestLiveLogIntegration(t *testing.T) {
 		}
 
 		// Step 4.2 - Test inclusion proofs.
-		pb, err := client.NewProofBuilder(ctx, lst.Latest().Size, logReadTile)
+		pb, err := client.NewProofBuilder(ctx, lst.Latest().Size, cfg.LogReadTile)
 		if err != nil {
 			t.Errorf("client.NewProofBuilder: %v", err)
 		}
@@ -201,6 +145,7 @@ func TestLiveLogIntegration(t *testing.T) {
 }
 
 type entryWriter struct {
+	hc     *http.Client
 	addURL string
 }
 
@@ -209,7 +154,7 @@ func (w *entryWriter) add(ctx context.Context, entry []byte) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	resp, err := hc.Do(req)
+	resp, err := w.hc.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/integration/mirror/posix/mirror_test.go
+++ b/integration/mirror/posix/mirror_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 The Tessera Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mirror_test contains integration tests for the POSIX MTC mirror
+// and the POSIX conformance log.
+package mirror_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/transparency-dev/formats/log"
+	fnote "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/merkle/rfc6962"
+	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/api"
+	"github.com/transparency-dev/tessera/client"
+	"github.com/transparency-dev/tessera/cmd/mtc/mirror"
+	"github.com/transparency-dev/tessera/fsck"
+	iLog "github.com/transparency-dev/tessera/integration/log"
+	"github.com/transparency-dev/tessera/storage/posix"
+	witnessConfig "github.com/transparency-dev/witness/config"
+	"github.com/transparency-dev/witness/persistence/sqlite"
+	"github.com/transparency-dev/witness/witness"
+	"golang.org/x/mod/sumdb/note"
+)
+
+func TestPosixMirrorIntegration(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := t.Context()
+
+	const (
+		logOrigin    = "example.com/log/posix_mirror_test"
+		mirrorOrigin = "example.com/mirror/posix_mirror_test"
+	)
+
+	logSigner, logPubKey := mustGenerateMLDSACosigner(t, logOrigin)
+	mirrorSigner, mirrorPubKey := mustGenerateMLDSACosigner(t, mirrorOrigin)
+
+	// Storage directories.
+	logStorageDir := filepath.Join(tmpDir, "log_storage")
+	if err := os.MkdirAll(logStorageDir, 0o755); err != nil {
+		t.Fatalf("Failed to create log storage dir: %v", err)
+	}
+	mirrorStorageDir := filepath.Join(tmpDir, "mirror_storage")
+	if err := os.MkdirAll(mirrorStorageDir, 0o755); err != nil {
+		t.Fatalf("Failed to create mirror storage dir: %v", err)
+	}
+	mirrorLogDir := filepath.Join(mirrorStorageDir, "public/mirrors", fmt.Sprintf("%0x", sha256.Sum256([]byte(logOrigin))))
+	if err := os.MkdirAll(mirrorLogDir, 0o755); err != nil {
+		t.Fatalf("Failed to create mirror target dir: %v", err)
+	}
+	witnessDir := filepath.Join(mirrorStorageDir, "private/witness")
+	if err := os.MkdirAll(witnessDir, 0o700); err != nil {
+		t.Fatalf("Failed to create witness dir: %v", err)
+	}
+
+	// Create a signer-less witness to be used with the mirror service.
+	w, wp := mustCreateWitness(t, ctx, witnessDir)
+	// Provision test log onto witness
+	if err := wp.AddLogs(ctx, []witnessConfig.Log{{Origin: logOrigin, VKey: logPubKey}}); err != nil {
+		t.Fatalf("witness AddLogs: %v", err)
+	}
+
+	// Create the mirror service...
+	m, err := mirror.New(ctx, w, mirrorSigner, []mirror.LogConfig{
+		{
+			Log: witnessConfig.Log{
+				Origin:   logOrigin,
+				VKey:     logPubKey,
+				Verifier: logSigner.Verifier(),
+			},
+			Driver: mustCreateDriver(t, mirrorLogDir),
+		},
+	})
+	if err != nil {
+		t.Fatalf("mirror.New: %v", err)
+	}
+
+	mirrorServer := httptest.NewServer(m)
+	t.Cleanup(mirrorServer.Close)
+
+	// 3. Create mirror policy for the log pointing to the mirror server.
+	mirrorPolicyStr := fmt.Sprintf(`
+		witness mirror1 %s %s
+		group g1 all mirror1
+		quorum g1
+		`,
+		mirrorPubKey, mirrorServer.URL)
+
+	mirrorPolicy, err := tessera.NewWitnessGroupFromPolicy([]byte(mirrorPolicyStr))
+	if err != nil {
+		t.Fatalf("NewWitnessGroupFromPolicy: %v", err)
+	}
+
+	// 4. Programmatically instantiate the POSIX conformance log.
+	logDriver, err := posix.New(ctx, posix.Config{Path: logStorageDir})
+	if err != nil {
+		t.Fatalf("posix.New(log): %v", err)
+	}
+
+	logOpts := tessera.NewAppendOptions().
+		WithCheckpointSigner(logSigner).
+		WithCheckpointInterval(time.Second).
+		WithCheckpointRepublishInterval(time.Minute).
+		WithBatching(256, time.Second).
+		WithAntispam(tessera.DefaultAntispamInMemorySize, nil).
+		WithMirrors(mirrorPolicy, nil)
+
+	appender, shutdownAppender, lr, err := tessera.NewAppender(ctx, logDriver, logOpts)
+	if err != nil {
+		t.Fatalf("NewAppender: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = shutdownAppender(context.Background())
+	})
+
+	logMux := http.NewServeMux()
+	logMux.HandleFunc("POST /add", func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		idx, err := appender.Add(r.Context(), tessera.NewEntry(b))()
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(err.Error()))
+			return
+		}
+		_, _ = fmt.Fprintf(w, "%d", idx.Index)
+	})
+
+	conformanceServer := httptest.NewServer(logMux)
+	t.Cleanup(conformanceServer.Close)
+
+	// 5. Use the LiveIntegrationTest in integration_test.go with write_log_url set to the log and log_url set to the mirror.
+	iLog.LogIntegrationTest(t, iLog.LogIntegrationTestConfig{
+		LogReadTile:        lr.ReadTile,
+		LogReadCP:          lr.ReadCheckpoint,
+		LogReadEntryBundle: lr.ReadEntryBundle,
+		WriteLogURL:        conformanceServer.URL,
+		LogVerifier:        logSigner.Verifier(),
+		EntrySize:          uint64(1024),
+	})
+
+	// 6. Run fsck on both the log and mirror, and assert that the checkpoint size and root hashes of both match.
+	logFsck := fsck.New(logOrigin, logSigner.Verifier(), client.FileFetcher{Root: logStorageDir}, defaultMerkleLeafHasher, fsck.Opts{N: 1})
+	if err := logFsck.Check(ctx); err != nil {
+		t.Fatalf("fsck on log failed: %v", err)
+	}
+
+	mirrorFsck := fsck.New(logOrigin, logSigner.Verifier(), client.FileFetcher{Root: mirrorLogDir}, defaultMerkleLeafHasher, fsck.Opts{N: 1})
+	if err := mirrorFsck.Check(ctx); err != nil {
+		t.Fatalf("fsck on mirror failed: %v", err)
+	}
+
+	logCP, _, _, err := log.ParseCheckpoint(logFsck.Checkpoint(), logOrigin, logSigner.Verifier())
+	if err != nil {
+		t.Fatalf("Failed to parse log checkpoint: %v", err)
+	}
+
+	mirrorCP, _, _, err := log.ParseCheckpoint(mirrorFsck.Checkpoint(), logOrigin, logSigner.Verifier())
+	if err != nil {
+		t.Fatalf("Failed to parse mirror checkpoint: %v", err)
+	}
+
+	if logCP.Size != mirrorCP.Size {
+		t.Errorf("Checkpoint size mismatch: log size=%d, mirror size=%d", logCP.Size, mirrorCP.Size)
+	}
+	if !bytes.Equal(logCP.Hash, mirrorCP.Hash) {
+		t.Errorf("Checkpoint root hash mismatch: log hash=%x, mirror hash=%x", logCP.Hash, mirrorCP.Hash)
+	}
+	t.Logf("Successfully verified log and mirror matched: size=%d root=%x", logCP.Size, logCP.Hash)
+}
+
+func defaultMerkleLeafHasher(bundle []byte) ([][]byte, error) {
+	eb := &api.EntryBundle{}
+	if err := eb.UnmarshalText(bundle); err != nil {
+		return nil, fmt.Errorf("unmarshal: %v", err)
+	}
+	r := make([][]byte, 0, len(eb.Entries))
+	for _, e := range eb.Entries {
+		h := rfc6962.DefaultHasher.HashLeaf(e)
+		r = append(r, h[:])
+	}
+	return r, nil
+}
+
+func mustGenerateMLDSACosigner(t *testing.T, name string) (fnote.SubtreeSigner, string) {
+	t.Helper()
+
+	skey, vkey, err := fnote.GenerateMLDSAKey(name)
+	if err != nil {
+		t.Fatalf("Failed to generate key: %v", err)
+	}
+	signer, err := fnote.NewMLDSASigner(skey)
+	if err != nil {
+		t.Fatalf("Failed to generate signer: %v", err)
+	}
+	return signer, vkey
+}
+
+func mustCreateDriver(t *testing.T, path string) tessera.Driver {
+	t.Helper()
+	d, err := posix.New(t.Context(), posix.Config{Path: path})
+	if err != nil {
+		t.Fatalf("posix.New(mirror): %v", err)
+	}
+	return d
+}
+
+func mustCreateWitness(t *testing.T, ctx context.Context, dir string) (*witness.Witness, *sqlite.Persistence) {
+	t.Helper()
+	witnessPersistence, shutdownWitness, err := sqlite.New(ctx, sqlite.Opts{
+		Path: filepath.Join(dir, "witness.db"),
+	})
+	if err != nil {
+		t.Fatalf("Failed to create witness persistence: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = shutdownWitness()
+	})
+
+	w, err := witness.New(ctx, witness.Opts{
+		Persistence: witnessPersistence,
+		Signers:     []note.Signer{},
+		VerifierForLog: func(ctx context.Context, origin string) (note.Verifier, bool, error) {
+			log, ok, err := witnessPersistence.Log(ctx, origin)
+			if err != nil || !ok {
+				return nil, false, err
+			}
+			return log.Verifier, true, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create witness: %v", err)
+	}
+	return w, witnessPersistence
+}

--- a/integration/mirror/posix/mirror_test.go
+++ b/integration/mirror/posix/mirror_test.go
@@ -100,7 +100,7 @@ func TestPosixMirrorIntegration(t *testing.T) {
 	mirrorServer := httptest.NewServer(m)
 	t.Cleanup(mirrorServer.Close)
 
-	// 3. Create mirror policy for the log pointing to the mirror server.
+	// Create mirror policy for the log pointing to the mirror server.
 	mirrorPolicyStr := fmt.Sprintf(`
 		witness mirror1 %s %s
 		group g1 all mirror1
@@ -113,12 +113,7 @@ func TestPosixMirrorIntegration(t *testing.T) {
 		t.Fatalf("NewWitnessGroupFromPolicy: %v", err)
 	}
 
-	// 4. Programmatically instantiate the POSIX conformance log.
-	logDriver, err := posix.New(ctx, posix.Config{Path: logStorageDir})
-	if err != nil {
-		t.Fatalf("posix.New(log): %v", err)
-	}
-
+	logDriver := mustCreateDriver(t, logStorageDir)
 	logOpts := tessera.NewAppendOptions().
 		WithCheckpointSigner(logSigner).
 		WithCheckpointInterval(time.Second).
@@ -154,7 +149,7 @@ func TestPosixMirrorIntegration(t *testing.T) {
 	conformanceServer := httptest.NewServer(logMux)
 	t.Cleanup(conformanceServer.Close)
 
-	// 5. Use the LiveIntegrationTest in integration_test.go with write_log_url set to the log and log_url set to the mirror.
+	// Use the LiveIntegrationTest in integration_test.go with write_log_url set to the log and log_url set to the mirror.
 	iLog.LogIntegrationTest(t, iLog.LogIntegrationTestConfig{
 		LogReadTile:        lr.ReadTile,
 		LogReadCP:          lr.ReadCheckpoint,
@@ -164,7 +159,8 @@ func TestPosixMirrorIntegration(t *testing.T) {
 		EntrySize:          uint64(1024),
 	})
 
-	// 6. Run fsck on both the log and mirror, and assert that the checkpoint size and root hashes of both match.
+	// Run fsck on both the log and mirror, and assert that the checkpoint size and root hashes of both match, and that both checkpoints
+	// are signed by the log and the mirror.
 	logFsck := fsck.New(logOrigin, logSigner.Verifier(), client.FileFetcher{Root: logStorageDir}, defaultMerkleLeafHasher, fsck.Opts{N: 1})
 	if err := logFsck.Check(ctx); err != nil {
 		t.Fatalf("fsck on log failed: %v", err)
@@ -175,14 +171,20 @@ func TestPosixMirrorIntegration(t *testing.T) {
 		t.Fatalf("fsck on mirror failed: %v", err)
 	}
 
-	logCP, _, _, err := log.ParseCheckpoint(logFsck.Checkpoint(), logOrigin, logSigner.Verifier())
+	logCP, _, logN, err := log.ParseCheckpoint(logFsck.Checkpoint(), logOrigin, logSigner.Verifier(), mirrorSigner.Verifier())
 	if err != nil {
 		t.Fatalf("Failed to parse log checkpoint: %v", err)
 	}
+	if n := len(logN.Sigs); n != 2 {
+		t.Fatalf("Log checkpoint should have 2 signatures, got %d", n)
+	}
 
-	mirrorCP, _, _, err := log.ParseCheckpoint(mirrorFsck.Checkpoint(), logOrigin, logSigner.Verifier())
+	mirrorCP, _, mirrorN, err := log.ParseCheckpoint(mirrorFsck.Checkpoint(), logOrigin, logSigner.Verifier(), mirrorSigner.Verifier())
 	if err != nil {
 		t.Fatalf("Failed to parse mirror checkpoint: %v", err)
+	}
+	if n := len(mirrorN.Sigs); n != 2 {
+		t.Fatalf("Mirror checkpoint should have 2 signatures, got %d", n)
 	}
 
 	if logCP.Size != mirrorCP.Size {


### PR DESCRIPTION
This PR adds an end-to-end integration test for the mirror lifecycle, using POSIX as the storage.

Towards #945