### PR TITLE
[MTC] Store subtrees boundaries to build `AddTBS()` `MTCProof` structures

### DIFF
--- a/cmd/mtc/log/internal/checkpoint/reader.go
+++ b/cmd/mtc/log/internal/checkpoint/reader.go
@@ -139,9 +139,6 @@ func (r *Reader) SubtreeForIndex(index uint64) (start, end uint64, ok bool) {
 		}
 	}
 
-	if index < r.subtrees[0].start {
-		return 0, r.subtrees[0].start, true
-	}
-
-	return 0, 0, false
+	// If not found in retained subtrees, it must precede the earliest retained subtree.
+	return 0, r.subtrees[0].start, true
 }

--- a/cmd/mtc/log/internal/checkpoint/reader.go
+++ b/cmd/mtc/log/internal/checkpoint/reader.go
@@ -21,15 +21,31 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/tessera/internal/parse"
 )
 
-// Reader wraps a ReadCheckpoint function to cache the latest checkpoint size observed from storage.
+// maxSubtrees is the maximum number of recent subtrees kept in memory.
+// Retaining 16 subtrees covers 8+ checkpoint publication cycles, which is
+// enough to cover ongoing AddTBS requests.
+const maxSubtrees = 16
+
+// subtree represents a contiguous range of log entries [start, end).
+type subtree struct {
+	start uint64
+	end   uint64
+}
+
+// Reader wraps a ReadCheckpoint function to maintain an in-memory sliding window
+// of the most recently published subtrees.
 type Reader struct {
 	readCheckpoint func(context.Context) ([]byte, error)
 
-	mu         sync.RWMutex
-	latestSize uint64
+	mu sync.RWMutex
+	// subtrees stores the decomposition of successive [last_ckpt_size, new_ckpt_size)
+	// ranges into subtrees as per draft-ietf-plants-merkle-tree-certs Section 4.1.
+	// The `end` field of the last element is the latest tree size.
+	subtrees []subtree
 }
 
 // NewReader creates a new Reader instance wrapping readCheckpoint and reads the initial checkpoint from storage.
@@ -40,13 +56,14 @@ func NewReader(ctx context.Context, readCheckpoint func(context.Context) ([]byte
 	r := &Reader{
 		readCheckpoint: readCheckpoint,
 	}
+	// Populate subtrees with the two subtrees covering [0, checkpoint_size).
 	if _, err := r.Checkpoint(ctx); err != nil {
 		return nil, fmt.Errorf("initial checkpoint read: %v", err)
 	}
 	return r, nil
 }
 
-// Checkpoint reads the latest checkpoint from underlying storage and updates the latest observed size.
+// Checkpoint reads the latest checkpoint from storage and store corresponding subtrees.
 func (r *Reader) Checkpoint(ctx context.Context) ([]byte, error) {
 	rawCp, err := r.readCheckpoint(ctx)
 	if err != nil {
@@ -59,15 +76,72 @@ func (r *Reader) Checkpoint(ctx context.Context) ([]byte, error) {
 	}
 
 	r.mu.Lock()
-	r.latestSize = max(r.latestSize, size)
-	r.mu.Unlock()
+	defer r.mu.Unlock()
+
+	lastSize := uint64(0)
+	if len(r.subtrees) > 0 {
+		lastSize = r.subtrees[len(r.subtrees)-1].end
+	}
+
+	if size > lastSize {
+		s, mid, e, err := proof.FindSubtrees(lastSize, size)
+		if err != nil {
+			return nil, fmt.Errorf("find subtrees for [%d, %d): %w", lastSize, size, err)
+		}
+		if s < mid {
+			r.pushSubtreeLocked(subtree{start: s, end: mid})
+		}
+		if mid < e {
+			r.pushSubtreeLocked(subtree{start: mid, end: e})
+		}
+	}
 
 	return rawCp, nil
+}
+
+// pushSubtreeLocked adds a subtree and potentially removes old ones, capping the number of elements.
+// r.mu MUST be locked when calling this method.
+func (r *Reader) pushSubtreeLocked(st subtree) {
+	if len(r.subtrees) >= maxSubtrees {
+		copy(r.subtrees, r.subtrees[1:])
+		r.subtrees[len(r.subtrees)-1] = st
+	} else {
+		r.subtrees = append(r.subtrees, st)
+	}
 }
 
 // LatestSize returns the most recently observed checkpoint size.
 func (r *Reader) LatestSize() uint64 {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.latestSize
+	if len(r.subtrees) == 0 {
+		return 0
+	}
+	return r.subtrees[len(r.subtrees)-1].end
+}
+
+// SubtreeForIndex returns the exact [start, end) subtree covering index (start <= index < end).
+// If index precedes the earliest retained subtree, it returns [0, subtrees[0].start).
+func (r *Reader) SubtreeForIndex(index uint64) (start, end uint64, ok bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.subtrees) == 0 || index >= r.subtrees[len(r.subtrees)-1].end {
+		return 0, 0, false
+	}
+
+	// Search backwards from the end because index is almost always in the most
+	// recently added subtree (e.g. during AddTBS).
+	for i := len(r.subtrees) - 1; i >= 0; i-- {
+		st := r.subtrees[i]
+		if index >= st.start && index < st.end {
+			return st.start, st.end, true
+		}
+	}
+
+	if index < r.subtrees[0].start {
+		return 0, r.subtrees[0].start, true
+	}
+
+	return 0, 0, false
 }

--- a/cmd/mtc/log/internal/checkpoint/reader_test.go
+++ b/cmd/mtc/log/internal/checkpoint/reader_test.go
@@ -220,3 +220,129 @@ func TestReader_LatestSize(t *testing.T) {
 		})
 	}
 }
+
+func TestReader_SubtreeForIndex(t *testing.T) {
+	ctx := context.Background()
+	currentSize := uint64(0)
+
+	reader := func(_ context.Context) ([]byte, error) {
+		return mockCheckpoint("test.log", currentSize), nil
+	}
+
+	r, err := NewReader(ctx, reader)
+	if err != nil {
+		t.Fatalf("NewReader() error: %v", err)
+	}
+
+	// Add checkpoints: 50, 120, 200
+	// Subtrees created:
+	// [0, 50) -> [0, 32) and [32, 50)
+	// [50, 120) -> [48, 64) and [64, 120) (FindSubtrees expands left to power-of-2 48)
+	// [120, 200) -> [120, 128) and [128, 200)
+	for _, sz := range []uint64{50, 120, 200} {
+		currentSize = sz
+		if _, err := r.Checkpoint(ctx); err != nil {
+			t.Fatalf("Checkpoint(%d) error: %v", sz, err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		index     uint64
+		wantStart uint64
+		wantEnd   uint64
+		wantOK    bool
+	}{
+		{name: "first index of first subtree [0, 32)", index: 0, wantStart: 0, wantEnd: 32, wantOK: true},
+		{name: "middle of first subtree [0, 32)", index: 15, wantStart: 0, wantEnd: 32, wantOK: true},
+		{name: "last index of first subtree [0, 32)", index: 31, wantStart: 0, wantEnd: 32, wantOK: true},
+		{name: "first index of second subtree [32, 50)", index: 32, wantStart: 32, wantEnd: 50, wantOK: true},
+		{name: "middle of second subtree [32, 50)", index: 40, wantStart: 32, wantEnd: 50, wantOK: true},
+		{name: "overlapping index 48 in [48, 64)", index: 48, wantStart: 48, wantEnd: 64, wantOK: true},
+		{name: "overlapping index 49 in [48, 64)", index: 49, wantStart: 48, wantEnd: 64, wantOK: true},
+		{name: "first index of third subtree [48, 64)", index: 50, wantStart: 48, wantEnd: 64, wantOK: true},
+		{name: "last index of third subtree [48, 64)", index: 63, wantStart: 48, wantEnd: 64, wantOK: true},
+		{name: "first index of fourth subtree [64, 120)", index: 64, wantStart: 64, wantEnd: 120, wantOK: true},
+		{name: "middle of fourth subtree [64, 120)", index: 100, wantStart: 64, wantEnd: 120, wantOK: true},
+		{name: "last index of fourth subtree [64, 120)", index: 119, wantStart: 64, wantEnd: 120, wantOK: true},
+		{name: "first index of fifth subtree [120, 128)", index: 120, wantStart: 120, wantEnd: 128, wantOK: true},
+		{name: "last index of fifth subtree [120, 128)", index: 127, wantStart: 120, wantEnd: 128, wantOK: true},
+		{name: "first index of sixth subtree [128, 200)", index: 128, wantStart: 128, wantEnd: 200, wantOK: true},
+		{name: "last index of sixth subtree [128, 200)", index: 199, wantStart: 128, wantEnd: 200, wantOK: true},
+		{name: "index equal to latest checkpoint size", index: 200, wantOK: false},
+		{name: "future uncheckpointed index", index: 500, wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, ok := r.SubtreeForIndex(tc.index)
+			if ok != tc.wantOK {
+				t.Fatalf("SubtreeForIndex(%d) ok = %v, want %v", tc.index, ok, tc.wantOK)
+			}
+			if ok && (start != tc.wantStart || end != tc.wantEnd) {
+				t.Errorf("SubtreeForIndex(%d) = [%d, %d), want [%d, %d)", tc.index, start, end, tc.wantStart, tc.wantEnd)
+			}
+		})
+	}
+}
+
+func TestReader_CapacityPruning(t *testing.T) {
+	ctx := context.Background()
+	currentSize := uint64(0)
+
+	reader := func(_ context.Context) ([]byte, error) {
+		return mockCheckpoint("test.log", currentSize), nil
+	}
+
+	r, err := NewReader(ctx, reader)
+	if err != nil {
+		t.Fatalf("NewReader() error: %v", err)
+	}
+
+	numCheckpoints := maxSubtrees + 4
+	// Add checkpoints until capacity (maxSubtrees) is exceeded and pruning occurs
+	for i := uint64(1); i <= uint64(numCheckpoints); i++ {
+		currentSize += 50
+		if _, err := r.Checkpoint(ctx); err != nil {
+			t.Fatalf("Checkpoint(%d) error: %v", currentSize, err)
+		}
+	}
+
+	// Verify subtrees are capped at maxSubtrees
+	if len(r.subtrees) != maxSubtrees {
+		t.Fatalf("len(subtrees) = %d, want maxSubtrees %d", len(r.subtrees), maxSubtrees)
+	}
+
+	earliest := r.subtrees[0].start
+	// Index 0 was pruned from explicit subtrees since earliest subtree start has advanced past 0
+	if earliest == 0 {
+		t.Fatalf("earliest subtree start should have advanced past 0 after %d checkpoints", numCheckpoints)
+	}
+	// Index < earliest falls back to [0, earliest)
+	start, end, ok := r.SubtreeForIndex(0)
+	if !ok || start != 0 || end != earliest {
+		t.Errorf("SubtreeForIndex(0) = [%d, %d), ok=%v; want [0, %d), ok=true", start, end, ok, earliest)
+	}
+	start, end, ok = r.SubtreeForIndex(earliest - 1)
+	if !ok || start != 0 || end != earliest {
+		t.Errorf("SubtreeForIndex(%d) = [%d, %d), ok=%v; want [0, %d), ok=true", earliest-1, start, end, ok, earliest)
+	}
+
+	// Earliest remaining subtree is still valid
+	start, end, ok = r.SubtreeForIndex(earliest)
+	if !ok || start != r.subtrees[0].start || end != r.subtrees[0].end {
+		t.Errorf("SubtreeForIndex(%d) = [%d, %d), ok=%v; want [%d, %d), ok=true", earliest, start, end, ok, r.subtrees[0].start, r.subtrees[0].end)
+	}
+
+	// Latest subtree is valid
+	latest := r.subtrees[len(r.subtrees)-1]
+	start, end, ok = r.SubtreeForIndex(latest.start)
+	if !ok || start != latest.start || end != latest.end {
+		t.Errorf("SubtreeForIndex(%d) = [%d, %d), ok=%v; want [%d, %d), ok=true", latest.start, start, end, ok, latest.start, latest.end)
+	}
+
+	// Future index beyond latest size returns ok=false
+	if _, _, ok := r.SubtreeForIndex(latest.end); ok {
+		t.Errorf("SubtreeForIndex(%d) expected ok=false, got ok=true", latest.end)
+	}
+}

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -177,6 +177,7 @@ func (o *Options) WithMaxCertLifetime(duration time.Duration) *Options {
 type MTCLog struct {
 	a                 *tessera.Appender
 	reader            tessera.LogReader
+	cpReader          *checkpoint.Reader
 	awaiter           *tessera.PublicationAwaiter
 	landmarkPublisher *landmark.Publisher
 	maxCertLifetime   time.Duration
@@ -400,6 +401,7 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 	return &MTCLog{
 		a:                 a,
 		reader:            opts.reader,
+		cpReader:          cpReader,
 		awaiter:           tessera.NewPublicationAwaiter(ctx, cpReader.Checkpoint, opts.pollPeriod),
 		landmarkPublisher: pub,
 		maxCertLifetime:   opts.maxCertLifetime,
@@ -429,6 +431,13 @@ func (l *MTCLog) AddTBS(ctx context.Context, tbs TBSCertificateLogEntry) (*AddTB
 	if err != nil {
 		return nil, fmt.Errorf("error waiting for Tessera index future and its integration: %v", err)
 	}
+
+	start, end, ok := l.cpReader.SubtreeForIndex(idx.Index)
+	if !ok {
+		return nil, fmt.Errorf("subtree for index %d not found in recent checkpoint history", idx.Index)
+	}
+	_ = start
+	_ = end
 
 	// TODO: get subtree cosignatures
 	// TODO: build MTCProof


### PR DESCRIPTION
Towards #945.

This PR computes and fetches the subtree boundaries aligned with checkpoint sizes. We'll use these boundaries later to build consistency proofs for `AddTBS()` requests.