### PR TITLE
[MTC] Use IANA PEN 32473 instead of 44363

### DIFF
--- a/cmd/mtc/log/hammer/hammer.go
+++ b/cmd/mtc/log/hammer/hammer.go
@@ -69,7 +69,7 @@ var (
 	maxWriteOpsPerSecond = flag.Int("max_write_ops", 0, "The maximum number of write operations per second")
 	numWriters           = flag.Int("num_writers", 0, "The number of independent write tasks to run")
 
-	caID         = flag.String("ca_id", "44363.47", "The CA ID (e.g. 44363.47)")
+	caID         = flag.String("ca_id", "32473.106", "The CA ID (e.g. 32473.106)")
 	logNumber    = flag.Uint64("log_number", 1, "The issuance log number (strictly positive)")
 	certLifetime = flag.Duration("cert_lifetime", 24*time.Hour, "Validity duration for generated certificates")
 

--- a/cmd/mtc/log/internal/mtcproof/mtcproof_test.go
+++ b/cmd/mtc/log/internal/mtcproof/mtcproof_test.go
@@ -357,9 +357,9 @@ func TestParseCosignerID(t *testing.T) {
 			want:  []byte{0x81, 0xfd, 0x59, 0x01},
 		},
 		{
-			name:  "valid PEN 44363.47",
-			input: "oid/1.3.6.1.4.1.44363.47",
-			want:  []byte{0x82, 0xda, 0x4b, 0x2f},
+			name:  "valid PEN 32473.106",
+			input: "oid/1.3.6.1.4.1.32473.106",
+			want:  []byte{0x81, 0xfd, 0x59, 0x6a},
 		},
 		{
 			name:  "valid PEN 0",

--- a/cmd/mtc/log/mtc_test.go
+++ b/cmd/mtc/log/mtc_test.go
@@ -488,18 +488,18 @@ func TestFormatOriginAndSigner(t *testing.T) {
 	}{
 		{
 			name:           "valid single integer caID",
-			caID:           "44363",
+			caID:           "32473",
 			logNumber:      1,
-			wantOrigin:     "oid/1.3.6.1.4.1.44363.0.1",
-			wantSignerName: "oid/1.3.6.1.4.1.44363",
+			wantOrigin:     "oid/1.3.6.1.4.1.32473.0.1",
+			wantSignerName: "oid/1.3.6.1.4.1.32473",
 			wantErr:        false,
 		},
 		{
 			name:           "valid multi dot caID",
-			caID:           "44363.47",
+			caID:           "32473.106",
 			logNumber:      42,
-			wantOrigin:     "oid/1.3.6.1.4.1.44363.47.0.42",
-			wantSignerName: "oid/1.3.6.1.4.1.44363.47",
+			wantOrigin:     "oid/1.3.6.1.4.1.32473.106.0.42",
+			wantSignerName: "oid/1.3.6.1.4.1.32473.106",
 			wantErr:        false,
 		},
 		{
@@ -510,25 +510,25 @@ func TestFormatOriginAndSigner(t *testing.T) {
 		},
 		{
 			name:      "caID leading dot",
-			caID:      ".44363",
+			caID:      ".32473",
 			logNumber: 1,
 			wantErr:   true,
 		},
 		{
 			name:      "caID trailing dot",
-			caID:      "44363.",
+			caID:      "32473.",
 			logNumber: 1,
 			wantErr:   true,
 		},
 		{
 			name:      "caID invalid char",
-			caID:      "44363a",
+			caID:      "32473a",
 			logNumber: 1,
 			wantErr:   true,
 		},
 		{
 			name:      "logNumber zero",
-			caID:      "44363",
+			caID:      "32473",
 			logNumber: 0,
 			wantErr:   true,
 		},
@@ -551,7 +551,7 @@ func TestFormatOriginAndSigner(t *testing.T) {
 }
 
 func TestCreateSignerAndOrigin(t *testing.T) {
-	validKey, _, err := note.GenerateMLDSAKey("oid/1.3.6.1.4.1.44363.47")
+	validKey, _, err := note.GenerateMLDSAKey("oid/1.3.6.1.4.1.32473.106")
 	if err != nil {
 		t.Fatalf("GenerateMLDSAKey failed: %v", err)
 	}
@@ -567,11 +567,11 @@ func TestCreateSignerAndOrigin(t *testing.T) {
 	}{
 		{
 			name:           "valid matching key and caID",
-			caID:           "44363.47",
+			caID:           "32473.106",
 			logNumber:      1,
 			privKey:        validKey,
-			wantOrigin:     "oid/1.3.6.1.4.1.44363.47.0.1",
-			wantSignerName: "oid/1.3.6.1.4.1.44363.47",
+			wantOrigin:     "oid/1.3.6.1.4.1.32473.106.0.1",
+			wantSignerName: "oid/1.3.6.1.4.1.32473.106",
 			wantErr:        false,
 		},
 		{
@@ -583,14 +583,14 @@ func TestCreateSignerAndOrigin(t *testing.T) {
 		},
 		{
 			name:      "zero log number",
-			caID:      "44363.47",
+			caID:      "32473.106",
 			logNumber: 0,
 			privKey:   validKey,
 			wantErr:   true,
 		},
 		{
 			name:      "invalid private key string",
-			caID:      "44363.47",
+			caID:      "32473.106",
 			logNumber: 1,
 			privKey:   "not-a-valid-key",
 			wantErr:   true,

--- a/cmd/mtc/log/posix/README.md
+++ b/cmd/mtc/log/posix/README.md
@@ -17,13 +17,13 @@ generate ML-DSA key pairs in the correct `vkey` format with the
 command from the [witness](https://github.com/transparency-dev/witness) repo.
 
 The command below will generate such a key pair, with an origin of
-"oid/1.3.6.1.4.1.44363.47", writing the public and private keys out to
+"oid/1.3.6.1.4.1.32473.106", writing the public and private keys out to
 `/tmp/mtc.pub` and `/tmp/mtc.sec` respectively:
 
 ```bash
 go run github.com/transparency-dev/witness/cmd/generate_keys@main \
   --mldsa \
-  --origin "oid/1.3.6.1.4.1.44363.47" \
+  --origin "oid/1.3.6.1.4.1.32473.106" \
   --out_priv /tmp/mtc.sec \
   --out_pub /tmp/mtc.pub
 ```
@@ -41,7 +41,7 @@ An example command for starting the server is given below:
 go run ./cmd/mtc/log/posix \
   --listen_addr="localhost:6962" \
   --storage_dir="/tmp/mtclog" \
-  --ca_id="44363.47" \
+  --ca_id="32473.106" \
   --log_number=1 \
   --private_key=/tmp/mtc.sec \
   --slog_level=-4
@@ -55,7 +55,7 @@ In a different terminal, start the hammer:
 go run ./cmd/mtc/log/hammer \
   --log_url=file:///tmp/mtclog \
   --write_log_url=http://localhost:6962/ \
-  --ca_id="44363.47" \
+  --ca_id="32473.106" \
   --log_number=1 \
   --log_public_key=$(cat /tmp/mtc.pub) \
   --max_read_ops=10 \

--- a/cmd/mtc/log/posix/main.go
+++ b/cmd/mtc/log/posix/main.go
@@ -56,7 +56,7 @@ var (
 	clientHTTPMaxIdlePerHost = flag.Int("client_http_max_idle_per_host", 10, "Maximum number of idle HTTP connections per host for outgoing requests.")
 
 	// CA settings
-	caID            = flag.String("ca_id", "44363.47", "The CA ID as per draft-ietf-plants-merkle-tree-certs section 5.1 (e.g. 44363.47)")
+	caID            = flag.String("ca_id", "32473.106", "The CA ID as per draft-ietf-plants-merkle-tree-certs section 5.1 (e.g. 32473.106)")
 	logNumber       = flag.Uint64("log_number", 1, "The issuance log number (strictly positive)")
 	privKeyFile     = flag.String("private_key", "", "Location of private key file. If unset, uses the contents of the LOG_PRIVATE_KEY environment variable.")
 	maxCertLifetime = flag.Duration("max_cert_lifetime", log.DefaultMaxCertLifetime, "Maximum validity duration allowed for submitted certificate entries.")


### PR DESCRIPTION
Towards #945 

This PR uses Private Enterprise Number 32473 in tests and demos under `mtc/log`, as specified in https://www.rfc-editor.org/rfc/rfc5612.html.

`44363` is Cloudflare's PEN, and it's been used in https://ietf-plants-wg.github.io/merkle-tree-certs/draft-ietf-plants-merkle-tree-certs.html in X.509 extensions, but not for Trust Anchor IDs, like log IDs, or mirror IDs.

We should probably update `cmd/mtc/pemtovkey` as well, but we can do this in a follow-up PR.