### PR TITLE
[MTC] WithOrigin, WithSubtreeSigner, WithSubtreeWitnesses and WithHTTPClient options.

### DIFF
--- a/cmd/mtc/log/internal/handler/handlers_test.go
+++ b/cmd/mtc/log/internal/handler/handlers_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	fnote "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/cmd/mtc/log"
 	lmp "github.com/transparency-dev/tessera/cmd/mtc/log/internal/landmark/posix"
@@ -37,6 +38,23 @@ import (
 	"golang.org/x/crypto/cryptobyte/asn1"
 	"golang.org/x/mod/sumdb/note"
 )
+
+const (
+	testSignerName = "oid/1.3.6.1.4.1.32473.106"
+	testOrigin     = "oid/1.3.6.1.4.1.32473.106.0.1"
+)
+
+func mustTestSigner() fnote.SubtreeSigner {
+	validKey, _, err := fnote.GenerateMLDSAKey(testSignerName)
+	if err != nil {
+		panic(err)
+	}
+	s, err := fnote.NewMLDSASigner(validKey)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
 
 func setupTestLog(t *testing.T) *log.MTCLog {
 	t.Helper()
@@ -66,7 +84,9 @@ func setupTestLog(t *testing.T) *log.MTCLog {
 		WithTesseraReader(reader).
 		WithAwaiterPollInterval(20*time.Millisecond).
 		WithLandmarksStorage(lmp.NewStorage(storageDir)).
-		WithMaxCertLifetime(7*24*time.Hour))
+		WithMaxCertLifetime(7*24*time.Hour).
+		WithOrigin(testOrigin).
+		WithSubtreeSigner(mustTestSigner()))
 	if err != nil {
 		t.Fatalf("Failed to initialize MTC log: %v", err)
 	}

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"net/http"
+	"strings"
 	"time"
 
 	"github.com/transparency-dev/formats/note"
@@ -101,6 +103,10 @@ type Options struct {
 	landmarkStorage  landmark.LandmarksStorage
 	landmarkInterval time.Duration
 	maxCertLifetime  time.Duration
+	origin           string
+	subtreeSigner    note.SubtreeSigner
+	subtreeWitnesses tessera.WitnessGroup
+	httpClient       *http.Client
 }
 
 // NewOptions creates a new options struct for configuring MTCLog instances.
@@ -118,6 +124,12 @@ func (o *Options) valid() error {
 	}
 	if o.landmarkStorage == nil {
 		return errors.New("invalid Options: WithLandmarksStorage must be set")
+	}
+	if o.origin == "" {
+		return errors.New("invalid Options: WithOrigin must be set")
+	}
+	if o.subtreeSigner == nil {
+		return errors.New("invalid Options: WithSubtreeSigner must be set")
 	}
 	if o.landmarkInterval < 0 {
 		return errors.New("invalid Options: WithLandmarkInterval must be >= 0")
@@ -174,6 +186,32 @@ func (o *Options) WithMaxCertLifetime(duration time.Duration) *Options {
 	return o
 }
 
+// WithOrigin configures the MTC log origin (e.g. "oid/1.3.6.1.4.1.32473.1.0.1").
+func (o *Options) WithOrigin(origin string) *Options {
+	o.origin = origin
+	return o
+}
+
+// WithSubtreeSigner configures the signer used by the log to sign its own subtrees.
+func (o *Options) WithSubtreeSigner(s note.SubtreeSigner) *Options {
+	o.subtreeSigner = s
+	return o
+}
+
+// WithHTTPClient configures the HTTP client used for witness communications.
+// If unset or nil, http.DefaultClient is used.
+func (o *Options) WithHTTPClient(client *http.Client) *Options {
+	o.httpClient = client
+	return o
+}
+
+// WithSubtreeWitnesses configures the witness group policy and endpoints used
+// to obtain subtree cosignatures for MTC proofs.
+func (o *Options) WithSubtreeWitnesses(witnesses tessera.WitnessGroup) *Options {
+	o.subtreeWitnesses = witnesses
+	return o
+}
+
 type MTCLog struct {
 	a                 *tessera.Appender
 	reader            tessera.LogReader
@@ -181,6 +219,10 @@ type MTCLog struct {
 	awaiter           *tessera.PublicationAwaiter
 	landmarkPublisher *landmark.Publisher
 	maxCertLifetime   time.Duration
+	origin            string
+	subtreeSigner     note.SubtreeSigner
+	logCosignerID     []byte
+	subtreeWitnesses  tessera.WitnessGroup
 }
 
 // AddTBSRsp contains enough information from the log
@@ -398,6 +440,15 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 		return nil, fmt.Errorf("failed to initialise landmark publisher: %v", err)
 	}
 
+	logCosignerID, err := mtcproof.ParseCosignerID(opts.subtreeSigner.Name())
+	if err != nil {
+		return nil, fmt.Errorf("invalid subtree signer name %q: %w", opts.subtreeSigner.Name(), err)
+	}
+
+	if err := checkOriginSignerName(opts.origin, opts.subtreeSigner.Name()); err != nil {
+		return nil, fmt.Errorf("checkOrgiginSignerName: %v", err)
+	}
+
 	return &MTCLog{
 		a:                 a,
 		reader:            opts.reader,
@@ -405,6 +456,10 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 		awaiter:           tessera.NewPublicationAwaiter(ctx, cpReader.Checkpoint, opts.pollPeriod),
 		landmarkPublisher: pub,
 		maxCertLifetime:   opts.maxCertLifetime,
+		origin:            opts.origin,
+		subtreeSigner:     opts.subtreeSigner,
+		logCosignerID:     logCosignerID,
+		subtreeWitnesses:  opts.subtreeWitnesses,
 	}, nil
 }
 
@@ -565,4 +620,20 @@ func CreateSignerAndOrigin(caID string, logNumber uint64, privKey string) (origi
 		return "", nil, fmt.Errorf("signer key name %q does not match expected CA ID name %q", s.Name(), expectedSignerName)
 	}
 	return origin, s, nil
+}
+
+// checkOriginSigner verifies that an origin and signer match with each other.
+//
+// SPEC: draft-ietf-plants-merkle-tree-certs section 5.2.
+// "Each issuance log has a log ID, which is a trust anchor ID constructed by concatenating the following OID components:
+//   - The CA ID (Section 5.1)
+//   - The constant 0
+//   - The log number of the log"
+func checkOriginSignerName(origin, signer string) error {
+	// TODO: enforce here and elsewhere a max log number of 4.
+	expectedPrefix := signer + ".0."
+	if !strings.HasPrefix(origin, expectedPrefix) {
+		return fmt.Errorf("origin %q does not match subtree signer %q, must start with %q", origin, signer, expectedPrefix)
+	}
+	return nil
 }

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -451,7 +451,7 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 	}
 
 	if err := checkOriginSignerName(opts.origin, opts.subtreeSigner.Name()); err != nil {
-		return nil, fmt.Errorf("checkOrgiginSignerName: %v", err)
+		return nil, fmt.Errorf("checkOriginSignerName: %v", err)
 	}
 
 	return &MTCLog{

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -186,15 +186,20 @@ func (o *Options) WithMaxCertLifetime(duration time.Duration) *Options {
 	return o
 }
 
-// WithOrigin configures the MTC log origin (e.g. "oid/1.3.6.1.4.1.32473.1.0.1").
+// WithOrigin configures the log origin string used for subtree signatures.
+// origin MUST not be empty, otherwise valid() will fail.
+// The same origin MUST be used with Tessera's WithOrigin() option.
+// TODO: think of whether we could enforce this matching.
 func (o *Options) WithOrigin(origin string) *Options {
 	o.origin = origin
 	return o
 }
 
-// WithSubtreeSigner configures the signer used by the log to sign its own subtrees.
-func (o *Options) WithSubtreeSigner(s note.SubtreeSigner) *Options {
-	o.subtreeSigner = s
+// WithSubtreeSigner configures the signer used to produce subtree signatures for MTC proofs.
+// signer MUST not be nil, otherwise valid() will fail.
+// The same signer MUST be used with Tessera's WithCheckpointSigner() option.
+func (o *Options) WithSubtreeSigner(signer note.SubtreeSigner) *Options {
+	o.subtreeSigner = signer
 	return o
 }
 

--- a/cmd/mtc/log/mtc_test.go
+++ b/cmd/mtc/log/mtc_test.go
@@ -389,10 +389,29 @@ func (dummyLandmarksStorage) UpdateLandmarks(_ context.Context, fn func([]byte, 
 	return time.Now(), nil
 }
 
+const (
+	testSignerName = "oid/1.3.6.1.4.1.32473.106"
+	testOrigin     = "oid/1.3.6.1.4.1.32473.106.0.1"
+)
+
+func mustTestSigner() note.SubtreeSigner {
+	validKey, _, err := note.GenerateMLDSAKey(testSignerName)
+	if err != nil {
+		panic(err)
+	}
+	s, err := note.NewMLDSASigner(validKey)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
 func newDummyOptions() *Options {
 	return NewOptions().
 		WithTesseraReader(&dummyLogReader{}).
-		WithLandmarksStorage(&dummyLandmarksStorage{})
+		WithLandmarksStorage(&dummyLandmarksStorage{}).
+		WithOrigin(testOrigin).
+		WithSubtreeSigner(mustTestSigner())
 }
 
 func TestMTCOptionsValid(t *testing.T) {
@@ -411,7 +430,7 @@ func TestMTCOptionsValid(t *testing.T) {
 			wantErr: false,
 		}, {
 			name:    "Valid: order independence (interval before storage)",
-			opts:    NewOptions().WithTesseraReader(&dummyLogReader{}).WithLandmarkInterval(2 * time.Hour).WithLandmarksStorage(&dummyLandmarksStorage{}),
+			opts:    NewOptions().WithTesseraReader(&dummyLogReader{}).WithLandmarkInterval(2 * time.Hour).WithLandmarksStorage(&dummyLandmarksStorage{}).WithOrigin(testOrigin).WithSubtreeSigner(mustTestSigner()),
 			wantErr: false,
 		}, {
 			name:    "Valid: custom poll period",
@@ -423,11 +442,19 @@ func TestMTCOptionsValid(t *testing.T) {
 			wantErr: true,
 		}, {
 			name:    "Error: No TesseraReader",
-			opts:    NewOptions().WithLandmarksStorage(&dummyLandmarksStorage{}),
+			opts:    NewOptions().WithLandmarksStorage(&dummyLandmarksStorage{}).WithOrigin(testOrigin).WithSubtreeSigner(mustTestSigner()),
 			wantErr: true,
 		}, {
 			name:    "Error: No LandmarksStorage",
-			opts:    NewOptions().WithTesseraReader(&dummyLogReader{}),
+			opts:    NewOptions().WithTesseraReader(&dummyLogReader{}).WithOrigin(testOrigin).WithSubtreeSigner(mustTestSigner()),
+			wantErr: true,
+		}, {
+			name:    "Error: No Origin",
+			opts:    NewOptions().WithTesseraReader(&dummyLogReader{}).WithLandmarksStorage(&dummyLandmarksStorage{}).WithSubtreeSigner(mustTestSigner()),
+			wantErr: true,
+		}, {
+			name:    "Error: No SubtreeSigner",
+			opts:    NewOptions().WithTesseraReader(&dummyLogReader{}).WithLandmarksStorage(&dummyLandmarksStorage{}).WithOrigin(testOrigin),
 			wantErr: true,
 		}, {
 			name:    "Valid: Zero LandmarkInterval defaults to recommended",
@@ -629,66 +656,86 @@ func TestCreateSignerAndOrigin(t *testing.T) {
 }
 
 func TestNewMTCLog(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	opts := newDummyOptions()
+	ctx := t.Context()
 
-	t.Run("nil appender", func(t *testing.T) {
-		if _, err := NewMTCLog(ctx, nil, opts); err == nil {
-			t.Error("NewMTCLog with nil appender expected error, got nil")
-		}
-	})
+	badSignerKey, _, err := note.GenerateMLDSAKey("example.com/invalid")
+	if err != nil {
+		t.Fatalf("GenerateMLDSAKey failed: %v", err)
+	}
+	badSigner, err := note.NewMLDSASigner(badSignerKey)
+	if err != nil {
+		t.Fatalf("NewMLDSASigner failed: %v", err)
+	}
 
-	t.Run("nil options", func(t *testing.T) {
-		if _, err := NewMTCLog(ctx, &tessera.Appender{}, nil); err == nil {
-			t.Error("NewMTCLog with nil options expected error, got nil")
-		}
-	})
+	tests := []struct {
+		name     string
+		appender *tessera.Appender
+		opts     *Options
+		wantErr  bool
+	}{
+		{
+			name:     "valid default options (47-day certs)",
+			appender: &tessera.Appender{},
+			opts:     newDummyOptions(),
+			wantErr:  false,
+		},
+		{
+			name:     "valid 7-day certs with default interval",
+			appender: &tessera.Appender{},
+			opts:     newDummyOptions().WithMaxCertLifetime(7 * 24 * time.Hour),
+			wantErr:  false,
+		},
+		{
+			name:     "valid explicit 0 interval defaults to recommended",
+			appender: &tessera.Appender{},
+			opts:     newDummyOptions().WithLandmarkInterval(0),
+			wantErr:  false,
+		},
+		{
+			name:     "valid custom landmark interval",
+			appender: &tessera.Appender{},
+			opts: newDummyOptions().
+				WithMaxCertLifetime(20 * 24 * time.Hour).
+				WithLandmarkInterval(2 * time.Hour),
+			wantErr: false,
+		},
+		{
+			name:     "nil appender",
+			appender: nil,
+			opts:     newDummyOptions(),
+			wantErr:  true,
+		},
+		{
+			name:     "nil options",
+			appender: &tessera.Appender{},
+			opts:     nil,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid subtree signer name",
+			appender: &tessera.Appender{},
+			opts:     newDummyOptions().WithSubtreeSigner(badSigner),
+			wantErr:  true,
+		},
+		{
+			name:     "origin mismatch with subtree signer",
+			appender: &tessera.Appender{},
+			opts:     newDummyOptions().WithOrigin("oid/1.3.6.1.4.1.99999.0.1"),
+			wantErr:  true,
+		},
+	}
 
-	t.Run("valid default options (47-day certs)", func(t *testing.T) {
-		logInst, err := NewMTCLog(ctx, &tessera.Appender{}, opts)
-		if err != nil {
-			t.Fatalf("NewMTCLog unexpected error: %v", err)
-		}
-		if logInst == nil {
-			t.Fatal("NewMTCLog returned nil instance")
-		}
-	})
-
-	t.Run("valid 7-day certs with default interval", func(t *testing.T) {
-		opts7d := newDummyOptions().WithMaxCertLifetime(7 * 24 * time.Hour)
-		logInst, err := NewMTCLog(ctx, &tessera.Appender{}, opts7d)
-		if err != nil {
-			t.Fatalf("NewMTCLog unexpected error: %v", err)
-		}
-		if logInst == nil {
-			t.Fatal("NewMTCLog returned nil instance")
-		}
-	})
-
-	t.Run("valid explicit 0 interval defaults to recommended", func(t *testing.T) {
-		opts0 := newDummyOptions().WithLandmarkInterval(0)
-		logInst, err := NewMTCLog(ctx, &tessera.Appender{}, opts0)
-		if err != nil {
-			t.Fatalf("NewMTCLog unexpected error: %v", err)
-		}
-		if logInst == nil {
-			t.Fatal("NewMTCLog returned nil instance")
-		}
-	})
-
-	t.Run("valid custom landmark interval", func(t *testing.T) {
-		optsCustom := newDummyOptions().
-			WithMaxCertLifetime(20 * 24 * time.Hour).
-			WithLandmarkInterval(2 * time.Hour)
-		mtcLog, err := NewMTCLog(ctx, &tessera.Appender{}, optsCustom)
-		if err != nil {
-			t.Fatalf("NewMTCLog unexpected error: %v", err)
-		}
-		if mtcLog == nil {
-			t.Fatal("NewMTCLog returned nil instance")
-		}
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l, err := NewMTCLog(ctx, tc.appender, tc.opts)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NewMTCLog() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && l == nil {
+				t.Fatal("NewMTCLog() returned nil instance on success")
+			}
+		})
+	}
 }
 
 type parsedMTCProof struct {
@@ -798,7 +845,9 @@ func setupTestMTCLog(t *testing.T) *MTCLog {
 		WithTesseraReader(reader).
 		WithAwaiterPollInterval(20*time.Millisecond).
 		WithLandmarksStorage(dummyLandmarksStorage{}).
-		WithMaxCertLifetime(7*24*time.Hour))
+		WithMaxCertLifetime(7*24*time.Hour).
+		WithOrigin(testOrigin).
+		WithSubtreeSigner(mustTestSigner()))
 	if err != nil {
 		t.Fatalf("Failed to initialize MTC log: %v", err)
 	}

--- a/cmd/mtc/log/posix/main.go
+++ b/cmd/mtc/log/posix/main.go
@@ -67,19 +67,47 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 	ctx := context.Background()
 
+	var policy tessera.WitnessGroup
+	if *mirrorPolicyFile != "" {
+		b, err := os.ReadFile(*mirrorPolicyFile)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to read mirror policy", slog.Any("error", err), slog.String("path", *mirrorPolicyFile))
+			os.Exit(1)
+		}
+		policy, err = tessera.NewWitnessGroupFromPolicy(b)
+		if err != nil {
+			slog.ErrorContext(ctx, "Failed to parse mirror policy", slog.Any("error", err), slog.String("path", *mirrorPolicyFile))
+			os.Exit(1)
+		}
+		slog.InfoContext(ctx, "Mirroring enabled", slog.Any("policy", policy), slog.String("path", *mirrorPolicyFile))
+	}
+
 	origin, signer, err := log.CreateSignerAndOrigin(*caID, *logNumber, mustGetPrivateKey())
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create signer and origin", slog.Any("error", err))
 		os.Exit(1)
 	}
 
-	appender, shutdown, reader := newAppenderFromFlags(ctx, origin, signer)
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        *clientHTTPMaxIdle,
+			MaxIdleConnsPerHost: *clientHTTPMaxIdlePerHost,
+			DisableKeepAlives:   false,
+		},
+		Timeout: *clientHTTPTimeout,
+	}
+
+	appender, shutdown, reader := newAppenderFromFlags(ctx, origin, signer, policy, httpClient)
 	opts := log.NewOptions().
 		WithTesseraReader(reader).
 		WithAwaiterPollInterval(*awaiterPollInterval).
 		WithLandmarksStorage(lmp.NewStorage(*storageDir)).
 		WithLandmarkInterval(*landmarkInterval).
-		WithMaxCertLifetime(*maxCertLifetime)
+		WithMaxCertLifetime(*maxCertLifetime).
+		WithOrigin(origin).
+		WithSubtreeSigner(signer).
+		WithSubtreeWitnesses(policy).
+		WithHTTPClient(httpClient)
 	mtcLog, err := log.NewMTCLog(ctx, appender, opts)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to initialize MTC log", slog.Any("error", err))
@@ -139,7 +167,7 @@ func getKeyFile(path string) (string, error) {
 	return string(k), nil
 }
 
-func newAppenderFromFlags(ctx context.Context, origin string, signer note.SubtreeSigner) (*tessera.Appender, func(ctx context.Context) error, tessera.LogReader) {
+func newAppenderFromFlags(ctx context.Context, origin string, signer note.SubtreeSigner, policy tessera.WitnessGroup, httpClient *http.Client) (*tessera.Appender, func(ctx context.Context) error, tessera.LogReader) {
 	if *storageDir == "" {
 		slog.ErrorContext(ctx, "flag --storage_dir is required")
 		os.Exit(1)
@@ -154,30 +182,12 @@ func newAppenderFromFlags(ctx context.Context, origin string, signer note.Subtre
 		WithGarbageCollectionInterval(*garbageCollectionInterval)
 
 	if *mirrorPolicyFile != "" {
-		b, err := os.ReadFile(*mirrorPolicyFile)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to read mirror policy", slog.Any("error", err), slog.String("path", *mirrorPolicyFile))
-			os.Exit(1)
-		}
-		policy, err := tessera.NewWitnessGroupFromPolicy(b)
-		if err != nil {
-			slog.ErrorContext(ctx, "Failed to parse mirror policy", slog.Any("error", err), slog.String("path", *mirrorPolicyFile))
-			os.Exit(1)
-		}
 		opts = opts.WithMirrors(policy, nil)
-		slog.InfoContext(ctx, "Mirroring enabled", slog.Any("policy", policy), slog.String("path", *mirrorPolicyFile))
 	}
 
 	cfg := posix.Config{
-		Path: *storageDir,
-		HTTPClient: &http.Client{
-			Transport: &http.Transport{
-				MaxIdleConns:        *clientHTTPMaxIdle,
-				MaxIdleConnsPerHost: *clientHTTPMaxIdlePerHost,
-				DisableKeepAlives:   false,
-			},
-			Timeout: *clientHTTPTimeout,
-		},
+		Path:       *storageDir,
+		HTTPClient: httpClient,
 	}
 
 	driver, err := posix.New(ctx, cfg)


### PR DESCRIPTION
Towards #945 

These will be used to sign subtrees.
While I'm here:
 - add a `checkOriginSignerName` functions to make sure that the origin and the signer name match for an MTC Log
 - make `TestNewMTCLog` tests tabular