### PR TITLE
[MTC] Lazily cosign subtrees on demand with log signer

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -285,8 +285,10 @@ func subtreeNodes(start, end uint64) (proof.Nodes, error) {
 }
 
 // isSubtreeValid returns whether a subtree covers a valid range.
+// copied over from t-dev/merkle for the time being.
 func isSubtreeValid(start, end uint64) error {
 	bitCeil := func(n uint64) uint64 {
+		// copied over from t-dev/merkle for the time being.
 		if n <= 1 {
 			return 1
 		}
@@ -303,6 +305,7 @@ func isSubtreeValid(start, end uint64) error {
 		}
 		return nil
 	}
+
 	bc := bitCeil(l)
 	if start%bc != 0 {
 		return fmt.Errorf("start %d not a multiple of bit_ceil(end - start) = %d", start, bc)

--- a/client/client.go
+++ b/client/client.go
@@ -21,6 +21,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"math/bits"
 	"sync"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -247,6 +248,66 @@ func (pb *ProofBuilder) SubtreeInclusionProof(ctx context.Context, index, start,
 		}
 		return pb.materialiseProof(ctx, nodes)
 	})
+}
+
+// SubtreeRoot returns the root hash of the specified subtree range [start, end).
+func (pb *ProofBuilder) SubtreeRoot(ctx context.Context, start, end uint64) ([]byte, error) {
+	return otel.Trace(ctx, "tessera.client.SubtreeRoot", tracer, func(ctx context.Context, span trace.Span) ([]byte, error) {
+		if end > pb.treeSize {
+			return nil, fmt.Errorf("requested subtree root to %d which is larger than tree size %d", end, pb.treeSize)
+		}
+		nodes, err := subtreeNodes(start, end)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate subtree node list: %v", err)
+		}
+		h, err := pb.materialiseProof(ctx, nodes)
+		if err != nil {
+			return nil, err
+		}
+		rf := compact.RangeFactory{Hash: hasher.HashChildren}
+		r, err := rf.NewRange(0, end-start, h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create compact range for [%d, %d): %w", start, end, err)
+		}
+		return r.GetRootHash(nil)
+	})
+}
+
+// TODO: move/export subtreeNodes, isSubtreeValid and bitCeil to t-dev/merkle.
+// subtreeNodes returns the proof.Nodes required to compute the root hash of the subtree [start, end).
+func subtreeNodes(start, end uint64) (proof.Nodes, error) {
+	if err := isSubtreeValid(start, end); err != nil {
+		return proof.Nodes{}, err
+	}
+	return proof.Nodes{
+		IDs: compact.RangeNodes(start, end, nil),
+	}, nil
+}
+
+// isSubtreeValid returns whether a subtree covers a valid range.
+func isSubtreeValid(start, end uint64) error {
+	bitCeil := func(n uint64) uint64 {
+		if n <= 1 {
+			return 1
+		}
+		return 1 << (64 - bits.LeadingZeros64(n-1))
+	}
+
+	if start >= end {
+		return fmt.Errorf("start %d must be strictly less than end %d", start, end)
+	}
+	l := end - start
+	if l > 1<<63 {
+		if start != 0 {
+			return fmt.Errorf("start %d must be 0 when subtree length %d > 1<<63", start, l)
+		}
+		return nil
+	}
+	bc := bitCeil(l)
+	if start%bc != 0 {
+		return fmt.Errorf("start %d not a multiple of bit_ceil(end - start) = %d", start, bc)
+	}
+	return nil
 }
 
 // materialiseProof retrieves the specified proof nodes via pb's nodeCache, recreating ephemeral nodes if necessary.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -359,6 +359,26 @@ func TestProofBuilder_SubtreeRoot(t *testing.T) {
 		t.Fatalf("NewProofBuilder: %v", err)
 	}
 
+	tileRaw, err := testLogTileFetcher(ctx, 0, 0, 15)
+	if err != nil {
+		t.Fatalf("testLogTileFetcher: %v", err)
+	}
+	var tile api.HashTile
+	if err := tile.UnmarshalText(tileRaw); err != nil {
+		t.Fatalf("UnmarshalText: %v", err)
+	}
+	rf := compact.RangeFactory{Hash: hasher.HashChildren}
+	r := rf.NewEmptyRange(0)
+	for _, l := range tile.Nodes[8:12] {
+		if err := r.Append(l, nil); err != nil {
+			t.Fatalf("Append: %v", err)
+		}
+	}
+	want8to12, err := r.GetRootHash(nil)
+	if err != nil {
+		t.Fatalf("GetRootHash: %v", err)
+	}
+
 	tests := []struct {
 		name    string
 		start   uint64
@@ -371,6 +391,13 @@ func TestProofBuilder_SubtreeRoot(t *testing.T) {
 			start:   0,
 			end:     8,
 			want:    testCheckpoints[8].Hash,
+			wantErr: false,
+		},
+		{
+			name:    "valid range with non-zero start",
+			start:   8,
+			end:     12,
+			want:    want8to12,
 			wantErr: false,
 		},
 		{

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -351,6 +351,65 @@ func TestNodeFetcherAddressing(t *testing.T) {
 	}
 }
 
+func TestProofBuilder_SubtreeRoot(t *testing.T) {
+	ctx := t.Context()
+	cp := testCheckpoints[len(testCheckpoints)-1]
+	pb, err := NewProofBuilder(ctx, cp.Size, testLogTileFetcher)
+	if err != nil {
+		t.Fatalf("NewProofBuilder: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		start   uint64
+		end     uint64
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "valid range",
+			start:   0,
+			end:     8,
+			want:    testCheckpoints[8].Hash,
+			wantErr: false,
+		},
+		{
+			name:    "full tree range",
+			start:   0,
+			end:     cp.Size,
+			want:    cp.Hash,
+			wantErr: false,
+		},
+		{
+			name:    "invalid range",
+			start:   1,
+			end:     3,
+			wantErr: true,
+		},
+		{
+			name:    "end > treeSize",
+			start:   0,
+			end:     cp.Size + 1,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pb.SubtreeRoot(ctx, tc.start, tc.end)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("SubtreeRoot(%d, %d) error = %v, wantErr %v", tc.start, tc.end, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !bytes.Equal(got, tc.want) {
+				t.Errorf("SubtreeRoot(%d, %d) = %x, want %x", tc.start, tc.end, got, tc.want)
+			}
+		})
+	}
+}
+
 func BenchmarkProofBuilder(b *testing.B) {
 	ctx := context.Background()
 	const treeSize = 1_000_000

--- a/cmd/mtc/log/internal/checkpoint/reader.go
+++ b/cmd/mtc/log/internal/checkpoint/reader.go
@@ -120,9 +120,9 @@ func (r *Reader) makeSubtree(start, end uint64, rawCp []byte) subtree {
 		// signatures lazily retrieves and caches subtree signatures on first successful
 		// call. Errors are not cached to allow subsequent callers to retry.
 		//
-		// TODO: Consider using a detached or background context so that one caller's
-		// cancellation does not cancel in-flight signature fetching that other concurrent
-		// or future callers could benefit from.
+		// TODO: Consider using a detached, background context or retries so that
+		// context cancellation or HSM failure do not give up on signature fetching
+		// that other concurrent or future callers could benefit from.
 		signatures: func(ctx context.Context) ([]mtcproof.SubtreeSignature, error) {
 			mu.Lock()
 			defer mu.Unlock()

--- a/cmd/mtc/log/internal/checkpoint/reader.go
+++ b/cmd/mtc/log/internal/checkpoint/reader.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/mtcproof"
 	"github.com/transparency-dev/tessera/internal/parse"
 )
 
@@ -30,16 +31,21 @@ import (
 // enough to cover ongoing AddTBS requests.
 const maxSubtrees = 16
 
-// subtree represents a contiguous range of log entries [start, end).
+// GetSubtreeSigsFunc is called to produce signatures for a subtree [start, end).
+type GetSubtreeSigsFunc func(ctx context.Context, start, end uint64, rawCp []byte) ([]mtcproof.SubtreeSignature, error)
+
+// subtree represents a contiguous range of log entries [start, end) and its cached signatures.
 type subtree struct {
-	start uint64
-	end   uint64
+	start      uint64
+	end        uint64
+	signatures func(context.Context) ([]mtcproof.SubtreeSignature, error)
 }
 
 // Reader wraps a ReadCheckpoint function to maintain an in-memory sliding window
 // of the most recently published subtrees.
 type Reader struct {
 	readCheckpoint func(context.Context) ([]byte, error)
+	getSubtreeSigs GetSubtreeSigsFunc
 
 	mu sync.RWMutex
 	// subtrees stores the decomposition of successive [last_ckpt_size, new_ckpt_size)
@@ -49,12 +55,16 @@ type Reader struct {
 }
 
 // NewReader creates a new Reader instance wrapping readCheckpoint and reads the initial checkpoint from storage.
-func NewReader(ctx context.Context, readCheckpoint func(context.Context) ([]byte, error)) (*Reader, error) {
+func NewReader(ctx context.Context, readCheckpoint func(context.Context) ([]byte, error), getSubtreeSigs GetSubtreeSigsFunc) (*Reader, error) {
 	if readCheckpoint == nil {
 		return nil, errors.New("readCheckpoint must not be nil")
 	}
+	if getSubtreeSigs == nil {
+		return nil, errors.New("getSubtreeSigs must not be nil")
+	}
 	r := &Reader{
 		readCheckpoint: readCheckpoint,
+		getSubtreeSigs: getSubtreeSigs,
 	}
 	// Populate subtrees with the two subtrees covering [0, checkpoint_size).
 	if _, err := r.Checkpoint(ctx); err != nil {
@@ -63,7 +73,7 @@ func NewReader(ctx context.Context, readCheckpoint func(context.Context) ([]byte
 	return r, nil
 }
 
-// Checkpoint reads the latest checkpoint from storage and store corresponding subtrees.
+// Checkpoint reads the latest checkpoint from storage and stores corresponding subtrees.
 func (r *Reader) Checkpoint(ctx context.Context) ([]byte, error) {
 	rawCp, err := r.readCheckpoint(ctx)
 	if err != nil {
@@ -86,26 +96,57 @@ func (r *Reader) Checkpoint(ctx context.Context) ([]byte, error) {
 	if size > lastSize {
 		s, mid, e, err := proof.FindSubtrees(lastSize, size)
 		if err != nil {
-			return nil, fmt.Errorf("find subtrees for [%d, %d): %w", lastSize, size, err)
+			return nil, fmt.Errorf("find subtrees for [%d, %d): %v", lastSize, size, err)
 		}
 		if s < mid {
-			r.pushSubtreeLocked(subtree{start: s, end: mid})
+			r.pushSubtreeLocked(s, mid, rawCp)
 		}
 		if mid < e {
-			r.pushSubtreeLocked(subtree{start: mid, end: e})
+			r.pushSubtreeLocked(mid, e, rawCp)
 		}
 	}
 
 	return rawCp, nil
 }
 
+func (r *Reader) makeSubtree(start, end uint64, rawCp []byte) subtree {
+	var (
+		mu   sync.Mutex
+		sigs []mtcproof.SubtreeSignature
+	)
+	return subtree{
+		start: start,
+		end:   end,
+		// signatures lazily retrieves and caches subtree signatures on first successful
+		// call. Errors are not cached to allow subsequent callers to retry.
+		//
+		// TODO: Consider using a detached or background context so that one caller's
+		// cancellation does not cancel in-flight signature fetching that other concurrent
+		// or future callers could benefit from.
+		signatures: func(ctx context.Context) ([]mtcproof.SubtreeSignature, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if sigs != nil {
+				return sigs, nil
+			}
+			res, err := r.getSubtreeSigs(ctx, start, end, rawCp)
+			if err != nil {
+				return nil, err
+			}
+			sigs = res
+			return sigs, nil
+		},
+	}
+}
+
 // pushSubtreeLocked adds a subtree and potentially removes old ones, capping the number of elements.
 // When capacity is exceeded, the oldest delta subtree is merged into subtrees[0], keeping subtrees[0]
 // covering [0, subtrees[1].end) before shifting so that the log start is always anchored at 0.
 // r.mu MUST be locked when calling this method.
-func (r *Reader) pushSubtreeLocked(st subtree) {
+func (r *Reader) pushSubtreeLocked(start, end uint64, rawCp []byte) {
+	st := r.makeSubtree(start, end, rawCp)
 	if len(r.subtrees) >= maxSubtrees {
-		r.subtrees[0].end = r.subtrees[1].end
+		r.subtrees[0] = r.makeSubtree(0, r.subtrees[1].end, rawCp)
 		copy(r.subtrees[1:], r.subtrees[2:])
 		r.subtrees[len(r.subtrees)-1] = st
 	} else {
@@ -123,17 +164,18 @@ func (r *Reader) LatestSize() uint64 {
 	return r.subtrees[len(r.subtrees)-1].end
 }
 
-// SubtreeForIndex returns the exact [start, end) subtree covering index (start <= index < end).
-func (r *Reader) SubtreeForIndex(index uint64) (start, end uint64, err error) {
+// SubtreeForIndex returns the exact [start, end) subtree covering index (start <= index < end)
+// and a function to lazily compute/retrieve its signatures.
+func (r *Reader) SubtreeForIndex(index uint64) (start, end uint64, sigs func(context.Context) ([]mtcproof.SubtreeSignature, error), err error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	if len(r.subtrees) == 0 {
-		return 0, 0, errors.New("no subtrees available")
+		return 0, 0, nil, errors.New("no subtrees available")
 	}
 	latestSize := r.subtrees[len(r.subtrees)-1].end
 	if index >= latestSize {
-		return 0, 0, fmt.Errorf("index %d exceeds latest checkpoint size %d", index, latestSize)
+		return 0, 0, nil, fmt.Errorf("index %d exceeds latest checkpoint size %d", index, latestSize)
 	}
 
 	// Search backwards from the end because index is almost always in the most
@@ -141,11 +183,11 @@ func (r *Reader) SubtreeForIndex(index uint64) (start, end uint64, err error) {
 	for i := len(r.subtrees) - 1; i >= 0; i-- {
 		st := r.subtrees[i]
 		if index >= st.start && index < st.end {
-			return st.start, st.end, nil
+			return st.start, st.end, st.signatures, nil
 		}
 	}
 
 	// Since subtrees[0] always covers [0, ...), any index < LatestSize() should
 	// have been matched in the loop above.
-	return 0, 0, fmt.Errorf("no subtree covering index %d", index)
+	return 0, 0, nil, fmt.Errorf("no subtree covering index %d", index)
 }

--- a/cmd/mtc/log/internal/checkpoint/reader_test.go
+++ b/cmd/mtc/log/internal/checkpoint/reader_test.go
@@ -19,60 +19,81 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
+
+	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/mtcproof"
 )
 
 func mockCheckpoint(origin string, size uint64) []byte {
 	return []byte(fmt.Sprintf("%s\n%d\nAAAA\n", origin, size))
 }
 
+func dummyGetSubtreeSigs(_ context.Context, _, _ uint64, _ []byte) ([]mtcproof.SubtreeSignature, error) {
+	return nil, nil
+}
+
 func TestNewReader(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name     string
-		readCP   func(context.Context) ([]byte, error)
-		wantSize uint64
-		wantErr  bool
+		name           string
+		readCP         func(context.Context) ([]byte, error)
+		getSubtreeSigs GetSubtreeSigsFunc
+		wantSize       uint64
+		wantErr        bool
 	}{
 		{
 			name: "successful initial read",
 			readCP: func(_ context.Context) ([]byte, error) {
 				return mockCheckpoint("test.log", 100), nil
 			},
-			wantSize: 100,
+			getSubtreeSigs: dummyGetSubtreeSigs,
+			wantSize:       100,
 		},
 		{
 			name: "successful initial read with size 0",
 			readCP: func(_ context.Context) ([]byte, error) {
 				return mockCheckpoint("test.log", 0), nil
 			},
-			wantSize: 0,
+			getSubtreeSigs: dummyGetSubtreeSigs,
+			wantSize:       0,
 		},
 		{
-			name:    "nil readCheckpoint function",
-			readCP:  nil,
-			wantErr: true,
+			name:           "nil readCheckpoint function",
+			readCP:         nil,
+			getSubtreeSigs: dummyGetSubtreeSigs,
+			wantErr:        true,
+		},
+		{
+			name: "nil getSubtreeSigs function",
+			readCP: func(_ context.Context) ([]byte, error) {
+				return mockCheckpoint("test.log", 100), nil
+			},
+			getSubtreeSigs: nil,
+			wantErr:        true,
 		},
 		{
 			name: "storage error on initial read",
 			readCP: func(_ context.Context) ([]byte, error) {
 				return nil, errors.New("network error")
 			},
-			wantErr: true,
+			getSubtreeSigs: dummyGetSubtreeSigs,
+			wantErr:        true,
 		},
 		{
 			name: "malformed initial checkpoint",
 			readCP: func(_ context.Context) ([]byte, error) {
 				return []byte("not-a-valid-checkpoint"), nil
 			},
-			wantErr: true,
+			getSubtreeSigs: dummyGetSubtreeSigs,
+			wantErr:        true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			r, err := NewReader(ctx, tc.readCP)
+			r, err := NewReader(ctx, tc.readCP, tc.getSubtreeSigs)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("NewReader() error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -128,7 +149,7 @@ func TestReader_Checkpoint(t *testing.T) {
 			currentCP := mockCheckpoint("test.log", 100)
 			r, err := NewReader(ctx, func(_ context.Context) ([]byte, error) {
 				return currentCP, nil
-			})
+			}, dummyGetSubtreeSigs)
 			if err != nil {
 				t.Fatalf("NewReader() error: %v", err)
 			}
@@ -192,7 +213,7 @@ func TestReader_LatestSize(t *testing.T) {
 				return mockCheckpoint("test.log", currentSize), nil
 			}
 
-			r, err := NewReader(ctx, readCP)
+			r, err := NewReader(ctx, readCP, dummyGetSubtreeSigs)
 			if err != nil {
 				t.Fatalf("NewReader() unexpected error: %v", err)
 			}
@@ -229,7 +250,7 @@ func TestReader_SubtreeForIndex(t *testing.T) {
 		return mockCheckpoint("test.log", currentSize), nil
 	}
 
-	r, err := NewReader(ctx, reader)
+	r, err := NewReader(ctx, reader, dummyGetSubtreeSigs)
 	if err != nil {
 		t.Fatalf("NewReader() error: %v", err)
 	}
@@ -275,7 +296,7 @@ func TestReader_SubtreeForIndex(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			start, end, err := r.SubtreeForIndex(tc.index)
+			start, end, _, err := r.SubtreeForIndex(tc.index)
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("SubtreeForIndex(%d) error = %v, wantErr %v", tc.index, err, tc.wantErr)
 			}
@@ -294,7 +315,7 @@ func TestReader_CapacityPruning(t *testing.T) {
 		return mockCheckpoint("test.log", currentSize), nil
 	}
 
-	r, err := NewReader(ctx, reader)
+	r, err := NewReader(ctx, reader, dummyGetSubtreeSigs)
 	if err != nil {
 		t.Fatalf("NewReader() error: %v", err)
 	}
@@ -329,24 +350,141 @@ func TestReader_CapacityPruning(t *testing.T) {
 	}
 
 	// Verify SubtreeForIndex returns the first subtree for index 0 and index within subtrees[0].
-	start, end, err := r.SubtreeForIndex(0)
+	start, end, _, err := r.SubtreeForIndex(0)
 	if err != nil || start != 0 || end != r.subtrees[0].end {
 		t.Errorf("SubtreeForIndex(0) = [%d, %d), err=%v; want [0, %d), err=nil", start, end, err, r.subtrees[0].end)
 	}
-	start, end, err = r.SubtreeForIndex(r.subtrees[0].end - 1)
+	start, end, _, err = r.SubtreeForIndex(r.subtrees[0].end - 1)
 	if err != nil || start != 0 || end != r.subtrees[0].end {
 		t.Errorf("SubtreeForIndex(%d) = [%d, %d), err=%v; want [0, %d), err=nil", r.subtrees[0].end-1, start, end, err, r.subtrees[0].end)
 	}
 
 	// Latest subtree is valid
 	latest := r.subtrees[len(r.subtrees)-1]
-	start, end, err = r.SubtreeForIndex(latest.start)
+	start, end, _, err = r.SubtreeForIndex(latest.start)
 	if err != nil || start != latest.start || end != latest.end {
 		t.Errorf("SubtreeForIndex(%d) = [%d, %d), err=%v; want [%d, %d), err=nil", latest.start, start, end, err, latest.start, latest.end)
 	}
 
 	// Future index beyond latest size returns error
-	if _, _, err := r.SubtreeForIndex(latest.end); err == nil {
+	if _, _, _, err := r.SubtreeForIndex(latest.end); err == nil {
 		t.Errorf("SubtreeForIndex(%d) expected error, got nil", latest.end)
 	}
+}
+
+func TestReader_SubtreeSignatures(t *testing.T) {
+	ctx := t.Context()
+	dummySigs := []mtcproof.SubtreeSignature{
+		{CosignerID: []byte{1, 2, 3}, Signature: []byte("sig1")},
+	}
+
+	t.Run("lazy signature retrieval and caching on subsequent calls", func(t *testing.T) {
+		var sigCalls atomic.Int32
+		getSubtreeSigs := func(_ context.Context, start, end uint64, rawCp []byte) ([]mtcproof.SubtreeSignature, error) {
+			sigCalls.Add(1)
+			return dummySigs, nil
+		}
+
+		currentCP := mockCheckpoint("test.log", 100)
+		r, err := NewReader(ctx, func(_ context.Context) ([]byte, error) {
+			return currentCP, nil
+		}, getSubtreeSigs)
+		if err != nil {
+			t.Fatalf("NewReader() error: %v", err)
+		}
+
+		if got := sigCalls.Load(); got != 0 {
+			t.Fatalf("sigCalls before demand = %d, want 0", got)
+		}
+
+		start, end, getSigs, err := r.SubtreeForIndex(50)
+		if err != nil {
+			t.Fatalf("SubtreeForIndex(50) error = %v", err)
+		}
+		if start != 0 || end != 64 {
+			t.Errorf("SubtreeForIndex(50) = [%d, %d), want [0, 64)", start, end)
+		}
+
+		// First demand
+		sigs, err := getSigs(ctx)
+		if err != nil {
+			t.Fatalf("getSigs() unexpected error: %v", err)
+		}
+		if len(sigs) != len(dummySigs) {
+			t.Fatalf("getSigs() len = %d, want %d", len(sigs), len(dummySigs))
+		}
+		if got := sigCalls.Load(); got != 1 {
+			t.Fatalf("sigCalls after first demand = %d, want 1", got)
+		}
+
+		// Second demand (cached)
+		sigs2, err := getSigs(ctx)
+		if err != nil {
+			t.Fatalf("getSigs() second call unexpected error: %v", err)
+		}
+		if len(sigs2) != len(dummySigs) {
+			t.Fatalf("getSigs() second call len = %d, want %d", len(sigs2), len(dummySigs))
+		}
+		if got := sigCalls.Load(); got != 1 {
+			t.Fatalf("sigCalls after second demand = %d, want 1 (cached)", got)
+		}
+	})
+
+	t.Run("errors are not cached and can be retried", func(t *testing.T) {
+		var sigCalls atomic.Int32
+		failFirst := true
+		getSubtreeSigs := func(_ context.Context, start, end uint64, rawCp []byte) ([]mtcproof.SubtreeSignature, error) {
+			sigCalls.Add(1)
+			if failFirst {
+				failFirst = false
+				return nil, errors.New("transient failure")
+			}
+			return dummySigs, nil
+		}
+
+		currentCP := mockCheckpoint("test.log", 100)
+		r, err := NewReader(ctx, func(_ context.Context) ([]byte, error) {
+			return currentCP, nil
+		}, getSubtreeSigs)
+		if err != nil {
+			t.Fatalf("NewReader() error: %v", err)
+		}
+
+		_, _, getSigs, err := r.SubtreeForIndex(50)
+		if err != nil {
+			t.Fatalf("SubtreeForIndex(50) error = %v", err)
+		}
+
+		// First attempt fails
+		if _, err := getSigs(ctx); err == nil {
+			t.Fatal("first getSigs() expected error, got nil")
+		}
+		if got := sigCalls.Load(); got != 1 {
+			t.Fatalf("sigCalls after failed attempt = %d, want 1", got)
+		}
+
+		// Second attempt succeeds and caches
+		sigs, err := getSigs(ctx)
+		if err != nil {
+			t.Fatalf("second getSigs() unexpected error: %v", err)
+		}
+		if len(sigs) != len(dummySigs) {
+			t.Fatalf("second getSigs() len = %d, want %d", len(sigs), len(dummySigs))
+		}
+		if got := sigCalls.Load(); got != 2 {
+			t.Fatalf("sigCalls after retry = %d, want 2", got)
+		}
+
+		// Third attempt uses cached result
+		sigs3, err := getSigs(ctx)
+		if err != nil {
+			t.Fatalf("third getSigs() unexpected error: %v", err)
+		}
+		if len(sigs3) != len(dummySigs) {
+			t.Fatalf("third getSigs() len = %d, want %d", len(sigs3), len(dummySigs))
+		}
+		if got := sigCalls.Load(); got != 2 {
+			t.Fatalf("sigCalls after third attempt = %d, want 2 (cached)", got)
+		}
+	})
 }

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -35,6 +35,7 @@ import (
 	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/entry"
 	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/landmark"
 	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/mtcproof"
+	"github.com/transparency-dev/tessera/internal/parse"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 )
@@ -425,10 +426,31 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 		return nil, err
 	}
 
-	cpReader, err := checkpoint.NewReader(ctx, opts.reader.ReadCheckpoint)
+	logCosignerID, err := mtcproof.ParseCosignerID(opts.subtreeSigner.Name())
+	if err != nil {
+		return nil, fmt.Errorf("invalid subtree signer name %q: %w", opts.subtreeSigner.Name(), err)
+	}
+
+	if err := checkOriginSignerName(opts.origin, opts.subtreeSigner.Name()); err != nil {
+		return nil, fmt.Errorf("checkOriginSignerName: %v", err)
+	}
+
+	l := &MTCLog{
+		a:                a,
+		reader:           opts.reader,
+		maxCertLifetime:  opts.maxCertLifetime,
+		origin:           opts.origin,
+		subtreeSigner:    opts.subtreeSigner,
+		logCosignerID:    logCosignerID,
+		subtreeWitnesses: opts.subtreeWitnesses,
+	}
+
+	cpReader, err := checkpoint.NewReader(ctx, opts.reader.ReadCheckpoint, l.getSubtreeSigs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read initial checkpoint: %v", err)
 	}
+	l.cpReader = cpReader
+	l.awaiter = tessera.NewPublicationAwaiter(ctx, cpReader.Checkpoint, opts.pollPeriod)
 
 	interval := opts.landmarkInterval
 	if interval <= 0 {
@@ -444,27 +466,35 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialise landmark publisher: %v", err)
 	}
+	l.landmarkPublisher = pub
 
-	logCosignerID, err := mtcproof.ParseCosignerID(opts.subtreeSigner.Name())
+	return l, nil
+}
+
+func (l *MTCLog) getSubtreeSigs(ctx context.Context, start, end uint64, rawCp []byte) ([]mtcproof.SubtreeSignature, error) {
+	_, cpSize, _, err := parse.CheckpointUnsafe(rawCp)
 	if err != nil {
-		return nil, fmt.Errorf("invalid subtree signer name %q: %w", opts.subtreeSigner.Name(), err)
+		return nil, fmt.Errorf("failed to parse checkpoint: %v", err)
 	}
 
-	if err := checkOriginSignerName(opts.origin, opts.subtreeSigner.Name()); err != nil {
-		return nil, fmt.Errorf("checkOriginSignerName: %v", err)
+	pb, err := client.NewProofBuilder(ctx, cpSize, l.reader.ReadTile)
+	if err != nil {
+		return nil, fmt.Errorf("cannot create proof builder for [%d, %d): %v", start, end, err)
 	}
 
-	return &MTCLog{
-		a:                 a,
-		reader:            opts.reader,
-		cpReader:          cpReader,
-		awaiter:           tessera.NewPublicationAwaiter(ctx, cpReader.Checkpoint, opts.pollPeriod),
-		landmarkPublisher: pub,
-		maxCertLifetime:   opts.maxCertLifetime,
-		origin:            opts.origin,
-		subtreeSigner:     opts.subtreeSigner,
-		logCosignerID:     logCosignerID,
-		subtreeWitnesses:  opts.subtreeWitnesses,
+	subRoot, err := pb.SubtreeRoot(ctx, start, end)
+	if err != nil {
+		return nil, fmt.Errorf("cannot compute subtree root for [%d, %d): %v", start, end, err)
+	}
+
+	selfSig, err := l.subtreeSigner.SignSubtree(0, l.origin, start, end, subRoot)
+	if err != nil {
+		return nil, fmt.Errorf("cannot sign subtree [%d, %d): %v", start, end, err)
+	}
+
+	// TODO: fetch signatures from mirrors.
+	return []mtcproof.SubtreeSignature{
+		{CosignerID: l.logCosignerID, Signature: selfSig},
 	}, nil
 }
 
@@ -492,7 +522,7 @@ func (l *MTCLog) AddTBS(ctx context.Context, tbs TBSCertificateLogEntry) (*AddTB
 		return nil, fmt.Errorf("error waiting for Tessera index future and its integration: %v", err)
 	}
 
-	start, end, err := l.cpReader.SubtreeForIndex(idx.Index)
+	start, end, getSigs, err := l.cpReader.SubtreeForIndex(idx.Index)
 	if err != nil {
 		return nil, fmt.Errorf("no subtree covering index %d: %w", idx.Index, err)
 	}
@@ -506,12 +536,17 @@ func (l *MTCLog) AddTBS(ctx context.Context, tbs TBSCertificateLogEntry) (*AddTB
 		return nil, fmt.Errorf("cannot get subtree inclusion proof for index %d in subtree [%d, %d): %v", idx.Index, start, end, err)
 	}
 
+	subtreeSigs, err := getSigs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get subtree signatures: %v", err)
+	}
+
 	extBytes, err := entry.ExtractExtensions(eb)
 	if err != nil {
 		return nil, fmt.Errorf("cannot extract extensions: %v", err)
 	}
 
-	proofBytes, err := mtcproof.Serialize(extBytes, start, end, proofNodes, nil)
+	proofBytes, err := mtcproof.Serialize(extBytes, start, end, proofNodes, subtreeSigs)
 	if err != nil {
 		return nil, fmt.Errorf("cannot construct MTCProof: %v", err)
 	}

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -426,11 +426,11 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 		return nil, err
 	}
 
+	// Verify that the origin and signer name are valid.
 	logCosignerID, err := mtcproof.ParseCosignerID(opts.subtreeSigner.Name())
 	if err != nil {
 		return nil, fmt.Errorf("invalid subtree signer name %q: %w", opts.subtreeSigner.Name(), err)
 	}
-
 	if err := checkOriginSignerName(opts.origin, opts.subtreeSigner.Name()); err != nil {
 		return nil, fmt.Errorf("checkOriginSignerName: %v", err)
 	}

--- a/cmd/mtc/log/mtc_test.go
+++ b/cmd/mtc/log/mtc_test.go
@@ -926,6 +926,11 @@ func TestMTCLog_AddTBS(t *testing.T) {
 		{name: "entry 4 in single-entry subtree [4, 5)", entryIdx: 4, wantStart: 4, wantEnd: 5, wantProofLen: 0},
 	}
 
+	wantCosignerID, err := mtcproof.ParseCosignerID(mtcLog.subtreeSigner.Name())
+	if err != nil {
+		t.Fatalf("ParseCosignerID: %v", err)
+	}
+
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			rsp := responses[tc.entryIdx]
@@ -966,6 +971,15 @@ func TestMTCLog_AddTBS(t *testing.T) {
 			}
 			if len(subRoot) != 32 {
 				t.Fatalf("subRoot length = %d, want 32", len(subRoot))
+			}
+			if len(proofData.Signatures) != 1 {
+				t.Fatalf("got %d signatures, want 1", len(proofData.Signatures))
+			}
+			if !mtcLog.subtreeSigner.Verifier().VerifySubtree(0, mtcLog.origin, tc.wantStart, tc.wantEnd, subRoot, proofData.Signatures[0].Signature) {
+				t.Errorf("VerifySubtree failed for entry%d signature", tc.entryIdx)
+			}
+			if !bytes.Equal(proofData.Signatures[0].CosignerID, wantCosignerID) {
+				t.Errorf("CosignerID = %x, want %x", proofData.Signatures[0].CosignerID, wantCosignerID)
 			}
 		})
 	}


### PR DESCRIPTION
Towards #945.

This PR signs subtrees and caches signatures for all `AddTBS()` requests to use.

This is a starting point, and this can be improved later with:
 - better retries if need be
 - returning and exporting the `subtree` structure (let me know if you want that, and I'll do it in this or a followup PR, it made the diff too hard to consume)
 - moving some functions over to t-dev/merkle