### PR TITLE
[MTC] Strip timestamp from SubtreeSignature in MTCProof

### DIFF
--- a/cmd/mtc/log/internal/mtcproof/mtcproof.go
+++ b/cmd/mtc/log/internal/mtcproof/mtcproof.go
@@ -38,12 +38,36 @@ const (
 type hashValue [sha256.Size]byte
 
 // SubtreeSignature represents a cosigner's signature on a subtree root
-// as per draft-ietf-plants-merkle-tree-certs section 6.2:
+// as per draft-ietf-plants-merkle-tree-certs section 6.2.
 type SubtreeSignature struct {
 	// CosignerID is the binary representation of the trust anchor ID (1..255 bytes).
 	CosignerID []byte
-	// Signature is the raw signature bytes over the subtree.
+	// Signature is the raw signature bytes over the subtree (with no timestamp).
 	Signature []byte
+}
+
+// SPEC: https://c2sp.org/tlog-cosignature
+//
+//	"struct {
+//	   u64 timestamp;
+//	   select (signature_algorithm) {
+//	       case ed25519: opaque ed25519_signature[64];
+//	       case ml-dsa-44: opaque ml_dsa_44_signature[2420];
+//	   } signature;
+//	 } timestamped_signature;"
+//
+// NewSubtreeSignatureFromCosig creates a SubtreeSignature from a C2SP
+// timestamped_signature by stripping the timestamp prefix.
+func NewSubtreeSignatureFromCosig(cosignerID []byte, cosig []byte) (SubtreeSignature, error) {
+	s := cryptobyte.String(cosig)
+	var timestamp uint64
+	if !s.ReadUint64(&timestamp) {
+		return SubtreeSignature{}, fmt.Errorf("cosignature too short (%d bytes, missing u64 timestamp)", len(cosig))
+	}
+	return SubtreeSignature{
+		CosignerID: cosignerID,
+		Signature:  s,
+	}, nil
 }
 
 // mtcProof represents an MTC inclusion proof as per
@@ -178,18 +202,18 @@ func new(extensions []byte, start, end uint64, inclusionProof [][]byte, signatur
 //
 // opaque HashValue[HASH_SIZE];
 //
-// struct {
-//     TrustAnchorID cosigner_id;
-//     opaque signature<0..2^16-1>;
-// } SubtreeSignature;
+//	struct {
+//	    TrustAnchorID cosigner_id;
+//	    opaque signature<0..2^16-1>;
+//	} SubtreeSignature;
 //
-// struct {
-//     MTCLogEntryExtension extensions<0..2^16-1>;
-//     uint48 start;
-//     uint48 end;
-//     HashValue inclusion_proof<0..2^16-1>;
-//     SubtreeSignature signatures<0..2^16-1>;
-// } MTCProof;
+//	struct {
+//	    MTCLogEntryExtension extensions<0..2^16-1>;
+//	    uint48 start;
+//	    uint48 end;
+//	    HashValue inclusion_proof<0..2^16-1>;
+//	    SubtreeSignature signatures<0..2^16-1>;
+//	} MTCProof;
 func (p *mtcProof) marshal() ([]byte, error) {
 	var b cryptobyte.Builder
 

--- a/cmd/mtc/log/internal/mtcproof/mtcproof_test.go
+++ b/cmd/mtc/log/internal/mtcproof/mtcproof_test.go
@@ -17,6 +17,7 @@ package mtcproof
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"errors"
 	"reflect"
 	"strings"
@@ -429,6 +430,59 @@ func TestParseCosignerID(t *testing.T) {
 			}
 			if !bytes.Equal(got, tc.want) {
 				t.Errorf("ParseCosignerID(%q) = %x, want %x", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewSubtreeSignatureFromCosig(t *testing.T) {
+	cosignerID := []byte{0x2b, 0x06, 0x01, 0x04, 0x01}
+	rawSig := []byte("raw-signature-bytes")
+
+	tests := []struct {
+		name    string
+		input   []byte
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "valid cosignature with timestamp and signature",
+			input:   append(binary.BigEndian.AppendUint64(nil, 1724867400), rawSig...),
+			want:    rawSig,
+			wantErr: false,
+		},
+		{
+			name:    "valid cosignature with timestamp only",
+			input:   binary.BigEndian.AppendUint64(nil, 1724867400),
+			want:    []byte{},
+			wantErr: false,
+		},
+		{
+			name:    "too short (less than 8 bytes)",
+			input:   []byte{0x01, 0x02, 0x03},
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewSubtreeSignatureFromCosig(cosignerID, tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NewSubtreeSignatureFromCosig() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !bytes.Equal(got.CosignerID, cosignerID) {
+				t.Errorf("CosignerID = %x, want %x", got.CosignerID, cosignerID)
+			}
+			if !bytes.Equal(got.Signature, tc.want) {
+				t.Errorf("Signature = %x, want %x", got.Signature, tc.want)
 			}
 		})
 	}

--- a/cmd/mtc/log/internal/subtreewitness/gateway.go
+++ b/cmd/mtc/log/internal/subtreewitness/gateway.go
@@ -186,6 +186,9 @@ func (gw *Gateway) CosignSubtree(ctx context.Context, origin string, start, end 
 				slog.WarnContext(ctx, "Failed to decode witness subtree signature base64", slog.String("witness", s.Name), slog.Any("error", bErr))
 				continue
 			}
+			// SPEC: https://c2sp.org/signed-note
+			// "— <key name> base64(32-bit key ID || signature)"
+			// Remove the first 4 bytes to extract the C2SP timestamped_signature payload.
 			keyHash := s.Hash
 			sigBytes := raw[4:]
 
@@ -223,10 +226,16 @@ func (gw *Gateway) CosignSubtree(ctx context.Context, origin string, start, end 
 				continue
 			}
 
-			verifiedSubtreeSigs[k] = mtcproof.SubtreeSignature{
-				CosignerID: w.cosignerID,
-				Signature:  sigBytes,
+			subSig, err := mtcproof.NewSubtreeSignatureFromCosig(w.cosignerID, sigBytes)
+			if err != nil {
+				slog.ErrorContext(ctx, "Extracting raw subtree signature",
+					slog.String("witness", s.Name),
+					slog.Any("error", err),
+				)
+				continue
 			}
+
+			verifiedSubtreeSigs[k] = subSig
 			reconstructedCp = fmt.Appendf(reconstructedCp, "— %s %s\n", s.Name, b64)
 		}
 

--- a/cmd/mtc/log/internal/subtreewitness/gateway_test.go
+++ b/cmd/mtc/log/internal/subtreewitness/gateway_test.go
@@ -27,6 +27,7 @@ import (
 	f_log "github.com/transparency-dev/formats/log"
 	f_note "github.com/transparency-dev/formats/note"
 	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/mtcproof"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -41,14 +42,18 @@ func (m *mockSubtreeClient) SignSubtree(ctx context.Context, start, end uint64, 
 // mustSignSubtree signs a subtree and formats the signature as a note-style signature line.
 func mustSignSubtree(t *testing.T, s f_note.SubtreeSigner, origin string, start, end uint64, root []byte) (rawSig []byte, sigLine []byte) {
 	t.Helper()
-	rawSig, err := s.SignSubtree(0, origin, start, end, root)
+	noteSig, err := s.SignSubtree(0, origin, start, end, root)
 	if err != nil {
 		t.Fatalf("SignSubtree: %v", err)
 	}
 	buf := binary.BigEndian.AppendUint32(nil, s.KeyHash())
-	buf = append(buf, rawSig...)
+	buf = append(buf, noteSig...)
 	sigLine = []byte(fmt.Sprintf("— %s %s\n", s.Name(), base64.StdEncoding.EncodeToString(buf)))
-	return rawSig, sigLine
+	sigObj, err := mtcproof.NewSubtreeSignatureFromCosig(nil, noteSig)
+	if err != nil {
+		t.Fatalf("NewSubtreeSignatureFromCosig: %v", err)
+	}
+	return sigObj.Signature, sigLine
 }
 
 func TestNew(t *testing.T) {
@@ -160,10 +165,10 @@ func TestGateway_CosignSubtree(t *testing.T) {
 
 	rawSubSig, subSigLine := mustSignSubtree(t, signer1, origin, start, end, root)
 
-	corruptSubSig := bytes.Clone(rawSubSig)
-	corruptSubSig[0] ^= 0xff
+	corruptNoteSig, _ := signer1.SignSubtree(0, origin, start, end, root)
+	corruptNoteSig[len(corruptNoteSig)-1] ^= 0xff
 	corruptBuf := binary.BigEndian.AppendUint32(nil, signer1.KeyHash())
-	corruptBuf = append(corruptBuf, corruptSubSig...)
+	corruptBuf = append(corruptBuf, corruptNoteSig...)
 	corruptSubSigLine := []byte(fmt.Sprintf("— %s %s\n", signer1.Name(), base64.StdEncoding.EncodeToString(corruptBuf)))
 
 	u1, _ := url.Parse("https://wit1.example.com")

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -501,10 +501,12 @@ func (l *MTCLog) getSubtreeSigs(ctx context.Context, start, end uint64, rawCp []
 	if err != nil {
 		return nil, fmt.Errorf("cannot sign subtree [%d, %d): %v", start, end, err)
 	}
-
-	allSigs := []mtcproof.SubtreeSignature{
-		{CosignerID: l.logCosignerID, Signature: selfSig},
+	selfSubSig, err := mtcproof.NewSubtreeSignatureFromCosig(l.logCosignerID, selfSig)
+	if err != nil {
+		return nil, fmt.Errorf("cannot format self subtree signature: %w", err)
 	}
+
+	allSigs := []mtcproof.SubtreeSignature{selfSubSig}
 
 	if l.subtreeGateway != nil {
 		consProof, err := pb.SubtreeConsistencyProof(ctx, start, end)

--- a/cmd/mtc/log/mtc_test.go
+++ b/cmd/mtc/log/mtc_test.go
@@ -1072,13 +1072,20 @@ func TestMTCLog_AddTBS(t *testing.T) {
 			if len(proofData.Signatures) != 2 {
 				t.Fatalf("got %d signatures, want 2", len(proofData.Signatures))
 			}
-			if !mtcLog.subtreeSigner.Verifier().VerifySubtree(0, mtcLog.origin, tc.wantStart, tc.wantEnd, subRoot, proofData.Signatures[0].Signature) {
+			// SPEC: draft-ietf-plants-merkle-tree-certs section 6.2.
+			// SubtreeSignature.Signature contains the raw signature.
+			// SPEC: https://c2sp.org/tlog-cosignature
+			// note.SubtreeVerifier expects a C2SP timestamped_signature prefixed with the 8-byte u64 timestamp.
+			reconstructCosig := func(rawSig []byte) []byte {
+				return append(make([]byte, 8), rawSig...)
+			}
+			if !mtcLog.subtreeSigner.Verifier().VerifySubtree(0, mtcLog.origin, tc.wantStart, tc.wantEnd, subRoot, reconstructCosig(proofData.Signatures[0].Signature)) {
 				t.Errorf("VerifySubtree failed for log signature on entry%d", tc.entryIdx)
 			}
 			if !bytes.Equal(proofData.Signatures[0].CosignerID, mtcLog.logCosignerID) {
 				t.Errorf("CosignerID = %x, want %x", proofData.Signatures[0].CosignerID, mtcLog.logCosignerID)
 			}
-			if !witVerifier.VerifySubtree(0, mtcLog.origin, tc.wantStart, tc.wantEnd, subRoot, proofData.Signatures[1].Signature) {
+			if !witVerifier.VerifySubtree(0, mtcLog.origin, tc.wantStart, tc.wantEnd, subRoot, reconstructCosig(proofData.Signatures[1].Signature)) {
 				t.Errorf("VerifySubtree failed for witness signature on entry%d", tc.entryIdx)
 			}
 		})


### PR DESCRIPTION
Fixing a bug where we'd put the full signature returned from witnesses, without removing the zero timestamp.

Towards #945.