### PR TITLE
fix: update error message in subtree signature extraction log

### DIFF
--- a/cmd/mtc/log/internal/subtreewitness/gateway.go
+++ b/cmd/mtc/log/internal/subtreewitness/gateway.go
@@ -234,7 +234,7 @@ func (gw *Gateway) CosignSubtree(ctx context.Context, origin string, start, end 
 
 			subSig, err := mtcproof.NewSubtreeSignatureFromCosig(w.cosignerID, sigBytes)
 			if err != nil {
-				slog.ErrorContext(ctx, "Extracting raw subtree signature",
+				slog.ErrorContext(ctx, "Failed to extract raw subtree signature",
 					slog.String("witness", s.Name),
 					slog.Any("error", err),
 				)


### PR DESCRIPTION
This is a follow up PR for https://github.com/transparency-dev/tessera/pull/1145.