### PR TITLE
fix: return temporary filename on write error instead of empty string in POSIX

### DIFF
--- a/cmd/mtc/log/internal/landmark/posix/file_ops.go
+++ b/cmd/mtc/log/internal/landmark/posix/file_ops.go
@@ -183,9 +183,9 @@ func createTemp(prefix string, d []byte) (name string, err error) {
 	}()
 
 	if n, writeErr := f.Write(d); writeErr != nil {
-		return "", fmt.Errorf("failed to write to temporary file %q: %w", name, writeErr)
+		return name, fmt.Errorf("failed to write to temporary file %q: %w", name, writeErr)
 	} else if l := len(d); n < l {
-		return "", fmt.Errorf("short write on %q, %d < %d", name, n, l)
+		return name, fmt.Errorf("short write on %q, %d < %d", name, n, l)
 	}
 
 	return name, nil

--- a/storage/posix/file_ops.go
+++ b/storage/posix/file_ops.go
@@ -234,9 +234,9 @@ func createTemp(prefix string, d []byte) (name string, err error) {
 	}()
 
 	if n, writeErr := f.Write(d); writeErr != nil {
-		return "", fmt.Errorf("failed to write to temporary file %q: %w", name, writeErr)
+		return name, fmt.Errorf("failed to write to temporary file %q: %w", name, writeErr)
 	} else if l := len(d); n < l {
-		return "", fmt.Errorf("short write on %q, %d < %d", name, n, l)
+		return name, fmt.Errorf("short write on %q, %d < %d", name, n, l)
 	}
 
 	return name, nil


### PR DESCRIPTION
This fixes a resource leak in `createTemp` where incomplete temporary files are left stranded on disk if `f.Write` fails.

Due to the way named return variables evaluate in Go alongside `defer` blocks, explicitly doing a `return ""` upon a write error clears the `name` variable *before* the deferred cleanup block executes. This causes the cleanup defer block to execute `os.Remove("")` which fails silently, stranding the file.

Fixes the issue by returning `name` so it remains populated when the cleanup `defer` executes. The defer block then successfully removes the file by its path and concludes by clearing the `name` variable itself, preserving the expected `("", err)` return signature for the caller.