### PR TITLE
Migrate commands over to TLogPolicy

### DIFF
--- a/cmd/conformance/posix/main.go
+++ b/cmd/conformance/posix/main.go
@@ -33,6 +33,7 @@ import (
 	"log/slog"
 
 	fnote "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/formats/policy"
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/storage/posix"
 	badger_as "github.com/transparency-dev/tessera/storage/posix/antispam"
@@ -104,16 +105,16 @@ func main() {
 	if *mirrorPolicyFile != "" {
 		b, err := os.ReadFile(*mirrorPolicyFile)
 		if err != nil {
-			slog.ErrorContext(ctx, "Failed to read mirror policy", slog.Any("error", err))
+			slog.ErrorContext(ctx, "Failed to read mirror policy", slog.String("mirrorpolicyfile", *mirrorPolicyFile), slog.Any("error", err))
 			os.Exit(1)
 		}
-		policy, err := tessera.NewWitnessGroupFromPolicy(b)
-		if err != nil {
+		var mPol policy.TLogPolicy
+		if err := mPol.Unmarshal(b); err != nil {
 			slog.ErrorContext(ctx, "Failed to parse mirror policy", slog.Any("error", err))
 			os.Exit(1)
 		}
-		opts = opts.WithMirrors(policy, nil)
-		slog.InfoContext(ctx, "Mirroring enabled", slog.Any("policy", policy))
+		opts = opts.WithMirrorPolicy(mPol, nil)
+		slog.InfoContext(ctx, "Mirroring enabled", slog.Any("policy", mPol))
 	}
 
 	appender, shutdown, _, err := tessera.NewAppender(ctx, driver, opts)

--- a/cmd/examples/posix-oneshot/main.go
+++ b/cmd/examples/posix-oneshot/main.go
@@ -31,6 +31,7 @@ import (
 
 	"log/slog"
 
+	"github.com/transparency-dev/formats/policy"
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/storage/posix"
 )
@@ -105,8 +106,8 @@ func main() {
 			slog.ErrorContext(ctx, "Failed to read witness policy file", slog.String("witnesspolicyfile", *witnessPolicyFile), slog.Any("error", err))
 			os.Exit(1)
 		}
-		wg, err := tessera.NewWitnessGroupFromPolicy(f)
-		if err != nil {
+		var wPol policy.TLogPolicy
+		if err := wPol.Unmarshal(f); err != nil {
 			slog.ErrorContext(ctx, "Failed to create witness group from policy", slog.Any("error", err))
 			os.Exit(1)
 		}
@@ -115,7 +116,7 @@ func main() {
 			FailOpen: *witnessFailOpen,
 			Timeout:  *witnessTimeout,
 		}
-		opts.WithWitnesses(wg, wOpts)
+		opts.WithWitnessPolicy(wPol, wOpts)
 	}
 
 	slog.DebugContext(ctx, "Creating appender")

--- a/cmd/mtc/log/posix/main.go
+++ b/cmd/mtc/log/posix/main.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/formats/policy"
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/cmd/mtc/log"
 	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/handler"
@@ -67,19 +68,25 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.Level(*slogLevel)})))
 	ctx := context.Background()
 
-	var policy tessera.WitnessGroup
+	var mPol policy.TLogPolicy
+	var witGroup tessera.WitnessGroup
 	if *mirrorPolicyFile != "" {
 		b, err := os.ReadFile(*mirrorPolicyFile)
 		if err != nil {
 			slog.ErrorContext(ctx, "Failed to read mirror policy", slog.Any("error", err), slog.String("path", *mirrorPolicyFile))
 			os.Exit(1)
 		}
-		policy, err = tessera.NewWitnessGroupFromPolicy(b)
-		if err != nil {
+		if err := mPol.Unmarshal(b); err != nil {
 			slog.ErrorContext(ctx, "Failed to parse mirror policy", slog.Any("error", err), slog.String("path", *mirrorPolicyFile))
 			os.Exit(1)
 		}
-		slog.InfoContext(ctx, "Mirroring enabled", slog.Any("policy", policy), slog.String("path", *mirrorPolicyFile))
+		var gErr error
+		witGroup, gErr = tessera.FromPolicy(mPol)
+		if gErr != nil {
+			slog.ErrorContext(ctx, "Failed to convert mirror policy to witness group", slog.Any("error", gErr), slog.String("path", *mirrorPolicyFile))
+			os.Exit(1)
+		}
+		slog.InfoContext(ctx, "Mirroring enabled", slog.Any("policy", mPol), slog.String("path", *mirrorPolicyFile))
 	}
 
 	origin, signer, err := log.CreateSignerAndOrigin(*caID, *logNumber, mustGetPrivateKey())
@@ -97,7 +104,7 @@ func main() {
 		Timeout: *clientHTTPTimeout,
 	}
 
-	appender, shutdown, reader := newAppenderFromFlags(ctx, origin, signer, policy, httpClient)
+	appender, shutdown, reader := newAppenderFromFlags(ctx, origin, signer, mPol, httpClient)
 	opts := log.NewOptions().
 		WithTesseraReader(reader).
 		WithAwaiterPollInterval(*awaiterPollInterval).
@@ -106,7 +113,7 @@ func main() {
 		WithMaxCertLifetime(*maxCertLifetime).
 		WithOrigin(origin).
 		WithSubtreeSigner(signer).
-		WithSubtreeWitnesses(policy).
+		WithSubtreeWitnesses(witGroup).
 		WithHTTPClient(httpClient)
 	mtcLog, err := log.NewMTCLog(ctx, appender, opts)
 	if err != nil {
@@ -167,7 +174,7 @@ func getKeyFile(path string) (string, error) {
 	return string(k), nil
 }
 
-func newAppenderFromFlags(ctx context.Context, origin string, signer note.SubtreeSigner, policy tessera.WitnessGroup, httpClient *http.Client) (*tessera.Appender, func(ctx context.Context) error, tessera.LogReader) {
+func newAppenderFromFlags(ctx context.Context, origin string, signer note.SubtreeSigner, mirrorPolicy policy.TLogPolicy, httpClient *http.Client) (*tessera.Appender, func(ctx context.Context) error, tessera.LogReader) {
 	if *storageDir == "" {
 		slog.ErrorContext(ctx, "flag --storage_dir is required")
 		os.Exit(1)
@@ -192,7 +199,7 @@ func newAppenderFromFlags(ctx context.Context, origin string, signer note.Subtre
 		// checkpoints MUST be served with a minimum of 2 cosignatures. One of these
 		// MUST be from the MTC CA Operator and one MUST be from a Mirroring Cosigner
 		// recognized by Chrome and not operated by the MTC CA Operator."
-		opts = opts.WithMirrors(policy, nil)
+		opts = opts.WithMirrorPolicy(mirrorPolicy, nil)
 	}
 
 	cfg := posix.Config{

--- a/integration/mirror/posix/mirror_test.go
+++ b/integration/mirror/posix/mirror_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/transparency-dev/formats/log"
 	fnote "github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/formats/policy"
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api"
@@ -101,16 +102,16 @@ func TestPosixMirrorIntegration(t *testing.T) {
 	t.Cleanup(mirrorServer.Close)
 
 	// Create mirror policy for the log pointing to the mirror server.
-	mirrorPolicyStr := fmt.Sprintf(`
+	mirrorPolicyRaw := fmt.Appendf(nil, `
 		witness mirror1 %s %s
 		group g1 all mirror1
 		quorum g1
 		`,
 		mirrorPubKey, mirrorServer.URL)
 
-	mirrorPolicy, err := tessera.NewWitnessGroupFromPolicy([]byte(mirrorPolicyStr))
-	if err != nil {
-		t.Fatalf("NewWitnessGroupFromPolicy: %v", err)
+	var mirrorPolicy policy.TLogPolicy
+	if err := mirrorPolicy.Unmarshal(mirrorPolicyRaw); err != nil {
+		t.Fatalf("policy.Unmarshal: %v", err)
 	}
 
 	logDriver := mustCreateDriver(t, logStorageDir)
@@ -120,7 +121,7 @@ func TestPosixMirrorIntegration(t *testing.T) {
 		WithCheckpointRepublishInterval(time.Minute).
 		WithBatching(256, time.Second).
 		WithAntispam(tessera.DefaultAntispamInMemorySize, nil).
-		WithMirrors(mirrorPolicy, nil)
+		WithMirrorPolicy(mirrorPolicy, nil)
 
 	appender, shutdownAppender, lr, err := tessera.NewAppender(ctx, logDriver, logOpts)
 	if err != nil {


### PR DESCRIPTION
This PR updates the binaries under `cmd` to use the `formats/policy` package.

Towards #1152