### PR TITLE
Migrate mtc/log internal implementation to use TLogPolicy

### DIFF
--- a/cmd/mtc/log/internal/subtreewitness/gateway.go
+++ b/cmd/mtc/log/internal/subtreewitness/gateway.go
@@ -23,12 +23,11 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
-	"net/url"
 	"slices"
 	"sync"
 
 	f_note "github.com/transparency-dev/formats/note"
-	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/formats/policy"
 	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/mtcproof"
 	wc "github.com/transparency-dev/witness/client/http"
 	"golang.org/x/mod/sumdb/note"
@@ -57,7 +56,7 @@ type SubtreeWitnessClient interface {
 // Gateway manages concurrent requests to subtree witnesses and evaluates policy satisfaction.
 type Gateway struct {
 	witnesses map[witnessKey]witness
-	policy    tessera.WitnessGroup
+	policy    policy.TLogPolicy
 }
 
 // New creates a new subtree witness Gateway.
@@ -65,39 +64,46 @@ type Gateway struct {
 // use ML-DSA signatures.
 // SPEC: [DRAFT] Chrome Quantum-resistant Root Program Policy, Version 0.3.0, Section 3.1.
 // "Mirroring Cosigner Keys MUST be ML-DSA-44"
-func New(httpClient *http.Client, policy tessera.WitnessGroup) (*Gateway, error) {
+func New(httpClient *http.Client, pol policy.TLogPolicy) (*Gateway, error) {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
 
 	witnesses := make(map[witnessKey]witness)
-	for uStr, vs := range policy.WitnessEndpoints() {
-		u, err := url.Parse(uStr)
+	for _, w := range pol.Witnesses {
+		if w.URL == nil {
+			return nil, fmt.Errorf("missing URL for subtree witness %q", w.Name)
+		}
+		v := w.Verifier
+		if v == nil {
+			return nil, fmt.Errorf("missing Verifier for witness %q", w.Name)
+		}
+		var sv f_note.SubtreeVerifier
+		sv, ok := v.(f_note.SubtreeVerifier)
+		if !ok {
+			// Ignore witnesses that do not implement SubtreeVerifier.
+			slog.WarnContext(context.Background(), "witness verifier does not implement SubtreeVerifier", slog.String("name", w.Name))
+			continue
+		}
+		cosignerID, err := mtcproof.ParseCosignerID(sv.Name())
 		if err != nil {
-			return nil, fmt.Errorf("invalid witness URL %q: %w", uStr, err)
+			return nil, fmt.Errorf("invalid cosigner ID for witness %s: %w", sv.Name(), err)
 		}
-		if len(vs) == 0 {
-			return nil, fmt.Errorf("no verifiers for witness %s", uStr)
+		k := witnessKey{name: sv.Name(), keyHash: sv.KeyHash()}
+		if _, exists := witnesses[k]; exists {
+			return nil, fmt.Errorf("duplicate witness %q with key hash %x", k.name, k.keyHash)
 		}
-		client := wc.NewWitness(u, httpClient)
-		for _, v := range vs {
-			if sv, ok := v.(f_note.SubtreeVerifier); ok {
-				cosignerID, err := mtcproof.ParseCosignerID(sv.Name())
-				if err != nil {
-					return nil, fmt.Errorf("invalid cosigner ID for witness %s: %w", sv.Name(), err)
-				}
-				witnesses[witnessKey{name: sv.Name(), keyHash: sv.KeyHash()}] = witness{
-					client:     client,
-					verifier:   sv,
-					cosignerID: cosignerID,
-				}
-			}
+		client := wc.NewWitness(w.URL, httpClient)
+		witnesses[k] = witness{
+			client:     client,
+			verifier:   sv,
+			cosignerID: cosignerID,
 		}
 	}
 
 	return &Gateway{
 		witnesses: witnesses,
-		policy:    policy,
+		policy:    pol,
 	}, nil
 }
 

--- a/cmd/mtc/log/internal/subtreewitness/gateway_test.go
+++ b/cmd/mtc/log/internal/subtreewitness/gateway_test.go
@@ -26,7 +26,7 @@ import (
 
 	f_log "github.com/transparency-dev/formats/log"
 	f_note "github.com/transparency-dev/formats/note"
-	"github.com/transparency-dev/tessera"
+	"github.com/transparency-dev/formats/policy"
 	"github.com/transparency-dev/tessera/cmd/mtc/log/internal/mtcproof"
 	"golang.org/x/mod/sumdb/note"
 )
@@ -48,7 +48,7 @@ func mustSignSubtree(t *testing.T, s f_note.SubtreeSigner, origin string, start,
 	}
 	buf := binary.BigEndian.AppendUint32(nil, s.KeyHash())
 	buf = append(buf, noteSig...)
-	sigLine = []byte(fmt.Sprintf("— %s %s\n", s.Name(), base64.StdEncoding.EncodeToString(buf)))
+	sigLine = fmt.Appendf(nil, "— %s %s\n", s.Name(), base64.StdEncoding.EncodeToString(buf))
 	sigObj, err := mtcproof.NewSubtreeSignatureFromCosig(nil, noteSig)
 	if err != nil {
 		t.Fatalf("NewSubtreeSignatureFromCosig: %v", err)
@@ -61,10 +61,16 @@ func TestNew(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateMLDSAKey: %v", err)
 	}
-	u1, _ := url.Parse("https://wit1.example.com")
-	wValid, err := tessera.NewWitness(vkeyValid, u1)
+	verValid, err := f_note.NewMLDSAVerifier(vkeyValid)
 	if err != nil {
-		t.Fatalf("NewWitness: %v", err)
+		t.Fatalf("NewMLDSAVerifier: %v", err)
+	}
+	u1, _ := url.Parse("https://wit1.example.com")
+	witValid := policy.Witness{
+		Name:     verValid.Name(),
+		URL:      u1,
+		VKey:     vkeyValid,
+		Verifier: verValid,
 	}
 
 	_, vkeyNonSubtree, err := note.GenerateKey(nil, "non-subtree-witness")
@@ -72,61 +78,92 @@ func TestNew(t *testing.T) {
 		t.Fatalf("GenerateKey: %v", err)
 	}
 	u2, _ := url.Parse("https://wit2.example.com")
-	wNonSubtree, err := tessera.NewWitness(vkeyNonSubtree, u2)
+	vNonSubtree, err := f_note.NewVerifierForCosignatureV1(vkeyNonSubtree)
 	if err != nil {
-		t.Fatalf("NewWitness: %v", err)
+		t.Fatalf("NewVerifierForCosignatureV1: %v", err)
+	}
+	witNonSubtree := policy.Witness{
+		Name:     vNonSubtree.Name(),
+		URL:      u2,
+		VKey:     vkeyNonSubtree,
+		Verifier: vNonSubtree,
 	}
 
 	_, vkeyInvalidName, err := f_note.GenerateMLDSAKey("invalid-name-not-oid")
 	if err != nil {
 		t.Fatalf("GenerateMLDSAKey: %v", err)
 	}
-	u3, _ := url.Parse("https://wit3.example.com")
-	wInvalidName, err := tessera.NewWitness(vkeyInvalidName, u3)
+	verInvalid, err := f_note.NewMLDSAVerifier(vkeyInvalidName)
 	if err != nil {
-		t.Fatalf("NewWitness: %v", err)
+		t.Fatalf("NewMLDSAVerifier: %v", err)
+	}
+	u3, _ := url.Parse("https://wit3.example.com")
+	witInvalidName := policy.Witness{
+		Name:     verInvalid.Name(),
+		URL:      u3,
+		VKey:     vkeyInvalidName,
+		Verifier: verInvalid,
 	}
 
 	tests := []struct {
 		name          string
-		policy        tessera.WitnessGroup
+		policy        policy.TLogPolicy
 		wantWitnesses int
 		wantErr       bool
 	}{
 		{
-			name:          "valid single subtree witness",
-			policy:        tessera.NewWitnessGroup(1, wValid),
+			name: "valid single subtree witness",
+			policy: policy.TLogPolicy{
+				Witnesses: []policy.Witness{witValid},
+				Quorum:    witValid.Name,
+			},
 			wantWitnesses: 1,
 			wantErr:       false,
 		},
 		{
-			name:          "non-subtree verifier is skipped",
-			policy:        tessera.NewWitnessGroup(1, wNonSubtree),
+			name: "non-subtree verifier is skipped",
+			policy: policy.TLogPolicy{
+				Witnesses: []policy.Witness{witNonSubtree},
+				Quorum:    witNonSubtree.Name,
+			},
 			wantWitnesses: 0,
 			wantErr:       false,
 		},
 		{
-			name:          "mixed subtree and non-subtree witnesses",
-			policy:        tessera.NewWitnessGroup(1, wValid, wNonSubtree),
+			name: "mixed subtree and non-subtree witnesses",
+			policy: policy.TLogPolicy{
+				Witnesses: []policy.Witness{witValid, witNonSubtree},
+				Groups: []policy.Group{
+					{
+						Name:      "group",
+						Threshold: 1,
+						Members:   []string{witValid.Name, witNonSubtree.Name},
+					},
+				},
+				Quorum: "group",
+			},
 			wantWitnesses: 1,
 			wantErr:       false,
 		},
 		{
-			name:          "invalid cosigner name in subtree verifier",
-			policy:        tessera.NewWitnessGroup(1, wInvalidName),
+			name: "invalid cosigner name in subtree verifier",
+			policy: policy.TLogPolicy{
+				Witnesses: []policy.Witness{witInvalidName},
+				Quorum:    witInvalidName.Name,
+			},
 			wantWitnesses: 0,
 			wantErr:       true,
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			gw, err := New(nil, tc.policy)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("NewGateway() error = %v, wantErr %v", err, tc.wantErr)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gw, err := New(nil, test.policy)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("New() error = %v, wantErr %v", err, test.wantErr)
 			}
-			if !tc.wantErr && len(gw.witnesses) != tc.wantWitnesses {
-				t.Errorf("got %d witnesses in gateway, want %d", len(gw.witnesses), tc.wantWitnesses)
+			if !test.wantErr && len(gw.witnesses) != test.wantWitnesses {
+				t.Errorf("got %d witnesses in gateway, want %d", len(gw.witnesses), test.wantWitnesses)
 			}
 		})
 	}
@@ -169,19 +206,25 @@ func TestGateway_CosignSubtree(t *testing.T) {
 	corruptNoteSig[len(corruptNoteSig)-1] ^= 0xff
 	corruptBuf := binary.BigEndian.AppendUint32(nil, signer1.KeyHash())
 	corruptBuf = append(corruptBuf, corruptNoteSig...)
-	corruptSubSigLine := []byte(fmt.Sprintf("— %s %s\n", signer1.Name(), base64.StdEncoding.EncodeToString(corruptBuf)))
+	corruptSubSigLine := fmt.Appendf(nil, "— %s %s\n", signer1.Name(), base64.StdEncoding.EncodeToString(corruptBuf))
 
 	u1, _ := url.Parse("https://wit1.example.com")
-	w1, err := tessera.NewWitness(vkey1, u1)
-	if err != nil {
-		t.Fatalf("NewWitness: %v", err)
+	policy1 := policy.TLogPolicy{
+		Witnesses: []policy.Witness{
+			{
+				Name:     ver1.Name(),
+				URL:      u1,
+				VKey:     vkey1,
+				Verifier: ver1,
+			},
+		},
+		Quorum: ver1.Name(),
 	}
-	policy1 := tessera.NewWitnessGroup(1, w1)
 
 	tests := []struct {
 		name       string
 		witnesses  map[witnessKey]witness
-		policy     tessera.WitnessGroup
+		policy     policy.TLogPolicy
 		rawCp      []byte
 		wantSigs   int
 		wantSubSig []byte
@@ -288,28 +331,28 @@ func TestGateway_CosignSubtree(t *testing.T) {
 		{
 			name:      "empty policy satisfied with empty gateway",
 			witnesses: map[witnessKey]witness{},
-			policy:    tessera.WitnessGroup{},
+			policy:    policy.TLogPolicy{Quorum: "none"},
 			rawCp:     rawCpNoWit,
 			wantSigs:  0,
 			wantErr:   nil,
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			gw := &Gateway{
-				witnesses: tc.witnesses,
-				policy:    tc.policy,
+				witnesses: test.witnesses,
+				policy:    test.policy,
 			}
-			verified, err := gw.CosignSubtree(context.Background(), origin, start, end, root, nil, tc.rawCp)
-			if !errors.Is(err, tc.wantErr) {
-				t.Fatalf("got error %v, want %v", err, tc.wantErr)
+			verified, err := gw.CosignSubtree(context.Background(), origin, start, end, root, nil, test.rawCp)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("got error %v, want %v", err, test.wantErr)
 			}
-			if len(verified) != tc.wantSigs {
-				t.Fatalf("got %d verified sigs, want %d", len(verified), tc.wantSigs)
+			if len(verified) != test.wantSigs {
+				t.Fatalf("got %d verified sigs, want %d", len(verified), test.wantSigs)
 			}
-			if tc.wantSigs > 0 && !bytes.Equal(verified[0].Signature, tc.wantSubSig) {
-				t.Errorf("got signature %x, want %x", verified[0].Signature, tc.wantSubSig)
+			if test.wantSigs > 0 && !bytes.Equal(verified[0].Signature, test.wantSubSig) {
+				t.Errorf("got signature %x, want %x", verified[0].Signature, test.wantSubSig)
 			}
 		})
 	}

--- a/cmd/mtc/log/mtc.go
+++ b/cmd/mtc/log/mtc.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/formats/policy"
 	"github.com/transparency-dev/tessera"
 	"github.com/transparency-dev/tessera/api/layout"
 	"github.com/transparency-dev/tessera/client"
@@ -100,15 +101,15 @@ const (
 
 // Options holds settings for configuring MTCLog instances.
 type Options struct {
-	reader           tessera.LogReader
-	pollPeriod       time.Duration
-	landmarkStorage  landmark.LandmarksStorage
-	landmarkInterval time.Duration
-	maxCertLifetime  time.Duration
-	origin           string
-	subtreeSigner    note.SubtreeSigner
-	subtreeWitnesses tessera.WitnessGroup
-	httpClient       *http.Client
+	reader               tessera.LogReader
+	pollPeriod           time.Duration
+	landmarkStorage      landmark.LandmarksStorage
+	landmarkInterval     time.Duration
+	maxCertLifetime      time.Duration
+	origin               string
+	subtreeSigner        note.SubtreeSigner
+	subtreeWitnessPolicy policy.TLogPolicy
+	httpClient           *http.Client
 }
 
 // NewOptions creates a new options struct for configuring MTCLog instances.
@@ -212,10 +213,10 @@ func (o *Options) WithHTTPClient(client *http.Client) *Options {
 	return o
 }
 
-// WithSubtreeWitnesses configures the witness group policy and endpoints used
+// WithSubtreeWitnessPolicy configures the witness policy and endpoints used
 // to obtain subtree cosignatures for MTC proofs.
-func (o *Options) WithSubtreeWitnesses(witnesses tessera.WitnessGroup) *Options {
-	o.subtreeWitnesses = witnesses
+func (o *Options) WithSubtreeWitnessPolicy(policy policy.TLogPolicy) *Options {
+	o.subtreeWitnessPolicy = policy
 	return o
 }
 
@@ -437,8 +438,8 @@ func NewMTCLog(ctx context.Context, a *tessera.Appender, opts *Options) (*MTCLog
 	}
 
 	var gateway *subtreewitness.Gateway
-	if len(opts.subtreeWitnesses.Components) > 0 {
-		gw, err := subtreewitness.New(opts.httpClient, opts.subtreeWitnesses)
+	if len(opts.subtreeWitnessPolicy.Witnesses) > 0 {
+		gw, err := subtreewitness.New(opts.httpClient, opts.subtreeWitnessPolicy)
 		if err != nil {
 			return nil, fmt.Errorf("creating subtree witness gateway: %w", err)
 		}

--- a/cmd/mtc/log/mtc_test.go
+++ b/cmd/mtc/log/mtc_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/transparency-dev/formats/note"
+	"github.com/transparency-dev/formats/policy"
 	"github.com/transparency-dev/merkle/proof"
 	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/transparency-dev/tessera"
@@ -678,14 +679,24 @@ func TestNewMTCLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateMLDSAKey: %v", err)
 	}
-	witURL, _ := url.Parse("http://wit1.example.com")
-	w1, err := tessera.NewWitness(vkey1, witURL)
+	ver1, err := note.NewMLDSAVerifier(vkey1)
 	if err != nil {
-		t.Fatalf("NewWitness: %v", err)
+		t.Fatalf("NewMLDSAVerifier: %v", err)
 	}
-	witnessGroup := tessera.NewWitnessGroup(1, w1)
+	witURL, _ := url.Parse("http://wit1.example.com")
+	witPolicy := policy.TLogPolicy{
+		Witnesses: []policy.Witness{
+			{
+				Name:     ver1.Name(),
+				URL:      witURL,
+				VKey:     vkey1,
+				Verifier: ver1,
+			},
+		},
+		Quorum: ver1.Name(),
+	}
 
-	tests := []struct {
+	for _, tc := range []struct {
 		name        string
 		appender    *tessera.Appender
 		opts        *Options
@@ -721,14 +732,14 @@ func TestNewMTCLog(t *testing.T) {
 		{
 			name:        "valid with single witness policy",
 			appender:    &tessera.Appender{},
-			opts:        newDummyOptions().WithSubtreeWitnesses(witnessGroup),
+			opts:        newDummyOptions().WithSubtreeWitnessPolicy(witPolicy),
 			wantGateway: true,
 			wantErr:     false,
 		},
 		{
-			name:        "valid with empty witness group",
+			name:        "valid with empty witness policy",
 			appender:    &tessera.Appender{},
-			opts:        newDummyOptions().WithSubtreeWitnesses(tessera.WitnessGroup{}),
+			opts:        newDummyOptions().WithSubtreeWitnessPolicy(policy.TLogPolicy{}),
 			wantGateway: false,
 			wantErr:     false,
 		},
@@ -756,9 +767,7 @@ func TestNewMTCLog(t *testing.T) {
 			opts:     newDummyOptions().WithOrigin("oid/1.3.6.1.4.1.99999.0.1"),
 			wantErr:  true,
 		},
-	}
-
-	for _, tc := range tests {
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			l, err := NewMTCLog(ctx, tc.appender, tc.opts)
 			if (err != nil) != tc.wantErr {
@@ -854,7 +863,7 @@ func unmarshalMTCProof(data []byte) (*parsedMTCProof, error) {
 	return &p, nil
 }
 
-func setupTestWitness(t *testing.T) (tessera.WitnessGroup, note.SubtreeVerifier) {
+func setupTestWitness(t *testing.T) (policy.TLogPolicy, note.SubtreeVerifier) {
 	t.Helper()
 	sKey, vKey, err := note.GenerateMLDSAKey("oid/1.3.6.1.4.1.32473.106.1")
 	if err != nil {
@@ -907,11 +916,18 @@ func setupTestWitness(t *testing.T) (tessera.WitnessGroup, note.SubtreeVerifier)
 	t.Cleanup(ts.Close)
 
 	witURL, _ := url.Parse(ts.URL)
-	w, err := tessera.NewWitness(vKey, witURL)
-	if err != nil {
-		t.Fatalf("NewWitness: %v", err)
+	pol := policy.TLogPolicy{
+		Witnesses: []policy.Witness{
+			{
+				Name:     verifier.Name(),
+				URL:      witURL,
+				VKey:     vKey,
+				Verifier: verifier,
+			},
+		},
+		Quorum: verifier.Name(),
 	}
-	return tessera.NewWitnessGroup(1, w), verifier
+	return pol, verifier
 }
 
 func setupTestMTCLog(t *testing.T) (*MTCLog, note.SubtreeVerifier) {
@@ -930,13 +946,13 @@ func setupTestMTCLog(t *testing.T) (*MTCLog, note.SubtreeVerifier) {
 		t.Fatalf("Failed to create test signer: %v", err)
 	}
 
-	witGroup, witVerifier := setupTestWitness(t)
+	witPolicy, witVerifier := setupTestWitness(t)
 
 	opts := tessera.NewAppendOptions().
 		WithCheckpointSigner(signer).
 		WithBatching(4, 500*time.Millisecond).
-		WithCheckpointInterval(500 * time.Millisecond).
-		WithWitnesses(witGroup, &tessera.WitnessOptions{Timeout: time.Second})
+		WithCheckpointInterval(500*time.Millisecond).
+		WithWitnessPolicy(witPolicy, &tessera.WitnessOptions{Timeout: time.Second})
 	appender, _, reader, err := tessera.NewAppender(ctx, driver, opts)
 	if err != nil {
 		t.Fatalf("Failed to initialize Tessera appender: %v", err)
@@ -949,7 +965,7 @@ func setupTestMTCLog(t *testing.T) (*MTCLog, note.SubtreeVerifier) {
 		WithMaxCertLifetime(7*24*time.Hour).
 		WithOrigin(testOrigin).
 		WithSubtreeSigner(mustTestSigner()).
-		WithSubtreeWitnesses(witGroup))
+		WithSubtreeWitnessPolicy(witPolicy))
 	if err != nil {
 		t.Fatalf("Failed to initialize MTC log: %v", err)
 	}

--- a/cmd/mtc/log/posix/main.go
+++ b/cmd/mtc/log/posix/main.go
@@ -69,7 +69,6 @@ func main() {
 	ctx := context.Background()
 
 	var mPol policy.TLogPolicy
-	var witGroup tessera.WitnessGroup
 	if *mirrorPolicyFile != "" {
 		b, err := os.ReadFile(*mirrorPolicyFile)
 		if err != nil {
@@ -78,12 +77,6 @@ func main() {
 		}
 		if err := mPol.Unmarshal(b); err != nil {
 			slog.ErrorContext(ctx, "Failed to parse mirror policy", slog.Any("error", err), slog.String("path", *mirrorPolicyFile))
-			os.Exit(1)
-		}
-		var gErr error
-		witGroup, gErr = tessera.FromPolicy(mPol)
-		if gErr != nil {
-			slog.ErrorContext(ctx, "Failed to convert mirror policy to witness group", slog.Any("error", gErr), slog.String("path", *mirrorPolicyFile))
 			os.Exit(1)
 		}
 		slog.InfoContext(ctx, "Mirroring enabled", slog.Any("policy", mPol), slog.String("path", *mirrorPolicyFile))
@@ -113,7 +106,7 @@ func main() {
 		WithMaxCertLifetime(*maxCertLifetime).
 		WithOrigin(origin).
 		WithSubtreeSigner(signer).
-		WithSubtreeWitnesses(witGroup).
+		WithSubtreeWitnessPolicy(mPol).
 		WithHTTPClient(httpClient)
 	mtcLog, err := log.NewMTCLog(ctx, appender, opts)
 	if err != nil {

--- a/witness.go
+++ b/witness.go
@@ -52,15 +52,6 @@ func NewWitnessGroupFromPolicy(p []byte) (WitnessGroup, error) {
 	return fromPolicy(ret)
 }
 
-// FromPolicy converts a [policy.TLogPolicy] to a [WitnessGroup].
-//
-// This is only needed while we're in the process of migrating this codebase to
-// TLogPolicy, and can be removed once the migration is complete and before
-// we cut a new release.
-func FromPolicy(p policy.TLogPolicy) (WitnessGroup, error) {
-	return fromPolicy(p)
-}
-
 func fromPolicy(p policy.TLogPolicy) (WitnessGroup, error) {
 	groups := make(map[string]WitnessGroup, len(p.Groups))
 	witnesses := make(map[string]Witness, len(p.Witnesses))
@@ -262,11 +253,6 @@ func groupExists(p *policy.TLogPolicy, grpName string) bool {
 		}
 	}
 	return false
-}
-
-// ToPolicy converts a [WitnessGroup] to a [policy.TLogPolicy].
-func (wg WitnessGroup) ToPolicy() (policy.TLogPolicy, error) {
-	return wg.toPolicy()
 }
 
 func (wg WitnessGroup) toPolicy() (policy.TLogPolicy, error) {


### PR DESCRIPTION
This PR updates the `mtc/log` implementation to use the `formats/policy` package.

Towards #1152