### PR TITLE
Migrate away from GCP's deprecated OTel exporter

### DIFF
--- a/cmd/conformance/gcp/otel.go
+++ b/cmd/conformance/gcp/otel.go
@@ -20,16 +20,17 @@ import (
 
 	"go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/oauth"
 
 	"log/slog"
 	"os"
-
-	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric" //nolint:staticcheck // https://github.com/transparency-dev/tessera/issues/1167
-	texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace" //nolint:staticcheck // https://github.com/transparency-dev/tessera/issues/1167
 )
 
 // initOTel initialises the open telemetry support for metrics and tracing.
@@ -66,7 +67,17 @@ func initOTel(ctx context.Context, traceFraction float64) func(context.Context) 
 		os.Exit(1)
 	}
 
-	me, err := mexporter.New() //nolint:staticcheck // https://github.com/transparency-dev/tessera/issues/1167
+	creds, err := oauth.NewApplicationDefault(ctx)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to load application default credentials", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	me, err := otlpmetricgrpc.New(
+		ctx,
+		otlpmetricgrpc.WithEndpoint("telemetry.googleapis.com:443"),
+		otlpmetricgrpc.WithDialOption(grpc.WithPerRPCCredentials(creds)),
+	)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create metric exporter", slog.Any("error", err))
 		os.Exit(1)
@@ -80,7 +91,11 @@ func initOTel(ctx context.Context, traceFraction float64) func(context.Context) 
 	shutdownFuncs = append(shutdownFuncs, mp.Shutdown)
 	otel.SetMeterProvider(mp)
 
-	te, err := texporter.New() //nolint:staticcheck // https://github.com/transparency-dev/tessera/issues/1167
+	te, err := otlptracegrpc.New(
+		ctx,
+		otlptracegrpc.WithEndpoint("telemetry.googleapis.com:443"),
+		otlptracegrpc.WithDialOption(grpc.WithPerRPCCredentials(creds)),
+	)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to create trace exporter", slog.Any("error", err))
 		os.Exit(1)

--- a/deployment/modules/gcp/conformance/main.tf
+++ b/deployment/modules/gcp/conformance/main.tf
@@ -49,11 +49,23 @@ resource "google_project_service" "cloudrun_api" {
   service            = "run.googleapis.com"
   disable_on_destroy = false
 }
-
 resource "google_project_service" "compute_engine" {
   service            = "compute.googleapis.com"
   disable_on_destroy = false
 }
+resource "google_project_service" "monitoring" {
+  service            = "monitoring.googleapis.com"
+  disable_on_destroy = false
+}
+resource "google_project_service" "logging" {
+  service            = "logging.googleapis.com"
+  disable_on_destroy = false
+}
+resource "google_project_service" "telemetry" {
+  service            = "telemetry.googleapis.com"
+  disable_on_destroy = false
+}
+
 
 locals {
   spanner_db_full = "projects/${var.project_id}/instances/${module.gcs.log_spanner_instance.name}/databases/${module.gcs.log_spanner_db.name}"

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,6 @@ toolchain go1.26.8
 require (
 	cloud.google.com/go/spanner v1.95.0
 	cloud.google.com/go/storage v1.66.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.61.0
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.37.0
 	github.com/RobinUS2/golang-moving-average v1.0.0
 	github.com/avast/retry-go/v4 v4.7.0
 	github.com/aws/aws-sdk-go-v2 v1.45.1
@@ -47,9 +45,9 @@ require (
 require (
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.30.0 // indirect
-	cloud.google.com/go/trace v1.16.0 // indirect
 	filippo.io/mldsa v0.0.0-20260215214346-43d0283efc3e // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.36.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.61.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.61.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.20 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.19.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.36.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.36.0/go.mod h1:1iIdl0k+ppn9wT0wzR9H7HkSvIui/4qgtnKW10cQtds=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.61.0 h1:BeC1Bub7Ttk33TF8v3ZeQ2L8acvz4ZLqtQuLyJAZquc=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.61.0/go.mod h1:UgG/Xn9+NXb1/ueSczIFxyuya3hs3srFDiZG2JrpJwY=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.37.0 h1:gCNy4R0LpSai5VjhxpLJ9MYP4Rc743e+GDL1H35L6pE=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.37.0/go.mod h1:fHRhIVN6YjLbKQNBxbv9FzW+A1NkFffpTMqqFGyT6oU=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.61.0 h1:eSgSuKdcpY7RTN1oXSzC6S39rPBImn03ubLMsWK4RRg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.61.0/go.mod h1:ifhe5teRNcbxg9p353DhOkOgczzL/IBLYFqT1cm1zpM=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.61.0 h1:KhpL26/GviYITHMCEGGqT/l50siFaBCBBKrjv6Z0G/k=


### PR DESCRIPTION
This PR migrates the GCP conformance binary over to using the new recommended approach.

Fixes #1167 